### PR TITLE
fix test for GET /class/student

### DIFF
--- a/dwengo_backend/controllers/student/studentClassController.ts
+++ b/dwengo_backend/controllers/student/studentClassController.ts
@@ -10,9 +10,9 @@ import { getUserFromAuthRequest } from "../../helpers/getUserFromAuthRequest";
  * returns a list of all classes the student is partaking in in the response body
  */
 export const getStudentClasses = asyncHandler(
-    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-        const studentId: number = getUserFromAuthRequest(req).id;
-        const classrooms = await classService.getClassesByStudent(studentId);
-        res.status(200).json({ classrooms });
-    }
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const studentId: number = getUserFromAuthRequest(req).id;
+    const classrooms = await classService.getClassesByStudent(studentId);
+    res.status(200).json({ classrooms });
+  },
 );

--- a/dwengo_backend/controllers/teacher/teacherClassController.ts
+++ b/dwengo_backend/controllers/teacher/teacherClassController.ts
@@ -2,7 +2,6 @@ import asyncHandler from "express-async-handler";
 import { Response } from "express";
 import { AuthenticatedRequest } from "../../middleware/teacherAuthMiddleware";
 import classService from "../../services/classService";
-import { Student, User } from "@prisma/client";
 import { getUserFromAuthRequest } from "../../helpers/getUserFromAuthRequest";
 import { BadRequestError } from "../../errors/errors";
 
@@ -10,7 +9,7 @@ const APP_URL = process.env.APP_URL || "http://localhost:5000";
 
 export const isTeacherValid = (
   req: AuthenticatedRequest,
-  res: Response
+  res: Response,
 ): boolean => {
   const teacherId = req.user?.id;
   if (!teacherId) {
@@ -20,10 +19,7 @@ export const isTeacherValid = (
   return true; // Teacher is authorized
 };
 
-export const isNameValid = (
-  req: AuthenticatedRequest,
-  res: Response
-): boolean => {
+export const isNameValid = (req: AuthenticatedRequest): boolean => {
   const { name } = req.body;
   if (!name || typeof name !== "string" || name.trim() === "") {
     throw new BadRequestError("Vul een geldige klasnaam in");
@@ -40,7 +36,7 @@ export const getTeacherClasses = asyncHandler(
     const teacherId: number = getUserFromAuthRequest(req).id;
     const classrooms = await classService.getClassesByTeacher(teacherId);
     res.status(200).json({ classrooms });
-  }
+  },
 );
 
 /**
@@ -52,11 +48,11 @@ export const createClassroom = asyncHandler(
     const { name } = req.body;
     const teacherId: number = getUserFromAuthRequest(req).id;
 
-    isNameValid(req, res); // if invalid, an error is thrown
+    isNameValid(req); // if invalid, an error is thrown
 
     const classroom = await classService.createClass(name, teacherId);
     res.status(201).json({ message: "Klas aangemaakt", classroom });
-  }
+  },
 );
 
 /**
@@ -70,7 +66,7 @@ export const deleteClassroom = asyncHandler(
 
     await classService.deleteClass(classId, teacherId);
     res.status(200).json({ message: `Klas met id ${classId} verwijderd` });
-  }
+  },
 );
 
 /**
@@ -83,11 +79,11 @@ export const updateClassroom = asyncHandler(
     const classId: number = parseInt(req.params.classId);
     const teacherId: number = getUserFromAuthRequest(req).id;
 
-    isNameValid(req, res); // if invalid, an error is thrown
+    isNameValid(req); // if invalid, an error is thrown
 
     const classroom = await classService.updateClass(classId, teacherId, name);
     res.status(200).json({ message: "Klas bijgewerkt", classroom });
-  }
+  },
 );
 
 /**
@@ -103,7 +99,7 @@ export const getJoinLink = asyncHandler(
 
     const joinLink = `${APP_URL}/class/teacher/join?joinCode=${joinCode}`;
     res.status(200).json({ joinLink });
-  }
+  },
 );
 
 /**
@@ -117,11 +113,11 @@ export const regenerateJoinLink = asyncHandler(
 
     const newJoinCode = await classService.regenerateJoinCode(
       classId,
-      teacherId
+      teacherId,
     );
     const joinLink = `${APP_URL}/class/teacher/join?joinCode=${newJoinCode}`;
     res.status(200).json({ joinLink });
-  }
+  },
 );
 
 /**
@@ -132,9 +128,12 @@ export const regenerateJoinLink = asyncHandler(
 export const getClassroomsStudents = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const teacherId: number = getUserFromAuthRequest(req).id;
-    const classrooms = await classService.getAllClassesByTeacher(teacherId, true);
+    const classrooms = await classService.getAllClassesByTeacher(
+      teacherId,
+      true,
+    );
     res.status(200).json({ classrooms });
-  }
+  },
 );
 
 /**
@@ -150,7 +149,7 @@ export const getStudentsByClassId = asyncHandler(
 
     const students = await classService.getStudentsByClass(classId, teacherId);
     res.status(200).json({ students });
-  }
+  },
 );
 
 /**
@@ -165,13 +164,11 @@ export const getAllClassrooms = asyncHandler(
     const includeStudents = req.query.includeStudents === "true";
     const classrooms = await classService.getAllClassesByTeacher(
       teacherId,
-      includeStudents
+      includeStudents,
     );
     res.status(200).json({ classrooms });
-  }
+  },
 );
-
-
 
 /**
  * Get classroom by ID
@@ -186,13 +183,12 @@ export const getClassByIdAndTeacherId = asyncHandler(
 
     const classroom = await classService.getClassByIdAndTeacherId(
       classId,
-      teacherId
+      teacherId,
     );
     if (!classroom) {
       throw new BadRequestError(`Klas met id ${classId} niet gevonden`);
     }
 
     res.status(200).json({ classroom });
-  }
+  },
 );
-

--- a/dwengo_backend/tests/class.test.ts
+++ b/dwengo_backend/tests/class.test.ts
@@ -36,7 +36,6 @@ describe("classroom tests", (): void => {
     classroom = await createClass("5A", "ABCD");
   });
 
-
   describe("[GET] /class/teacher", (): void => {
     it("should respond with a `200` status code and a list of classes", async (): Promise<void> => {
       // add teacherUser1 to some classes
@@ -62,7 +61,6 @@ describe("classroom tests", (): void => {
         ]),
       );
     });
-
 
     it("shouldn't allow a student to get the classes via the teacher route", async (): Promise<void> => {
       const studentUser: Prisma.UserGetPayload<{
@@ -103,7 +101,6 @@ describe("classroom tests", (): void => {
         .set("Authorization", `Bearer ${studentUser.token}`);
 
       expect(status).toBe(200);
-
       expectClassRoomArrayBody(body, classroom2);
     });
 
@@ -410,8 +407,8 @@ describe("classroom tests", (): void => {
 });
 
 function expectClassRoomArrayBody(body: any, classroom2: Class): void {
-  expect(body.classes).toBeDefined();
-  expect(body.classes).toEqual(
+  expect(body.classrooms).toBeDefined();
+  expect(body.classrooms).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         id: classroom.id,


### PR DESCRIPTION
Het probleem was dat de controller het resultaat teruggaf als `classrooms`, maar in de test werd dit nog gedaan met `classes`.
De aanpassingen in de controllers zijn gewoon de formatting en ongebruikte imports/vars die ik weg heb gedaan.