### PR TITLE
also get name and role when fetching question messages

### DIFF
--- a/dwengo_backend/prisma/schema.prisma
+++ b/dwengo_backend/prisma/schema.prisma
@@ -41,6 +41,8 @@ model User {
   admin   Admin?
   teacher Teacher?
   student Student?
+
+  QuestionMessage QuestionMessage[]
 }
 
 model Admin {
@@ -401,6 +403,7 @@ model QuestionMessage {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
   Questions  Question @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  user       User     @relation(fields: [userId], references: [id])
 }
 
 ///
@@ -409,16 +412,16 @@ model Assignment {
   id          Int      @id @default(autoincrement())
   title       String
   description String
-  pathRef    String
-  isExternal Boolean @default(false)
-  deadline         DateTime
-  createdAt        DateTime          @default(now())
-  updatedAt        DateTime          @updatedAt
-  teamSize  Int 
-  
+  pathRef     String
+  isExternal  Boolean  @default(false)
+  deadline    DateTime
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  teamSize    Int
+
   Questions        Question[]
-  classAssignments ClassAssignment[] 
-  teamAssignments  TeamAssignment[] 
+  classAssignments ClassAssignment[]
+  teamAssignments  TeamAssignment[]
 
   submissions Submission[]
 }


### PR DESCRIPTION
Zoals gevraagd in #260 krijg je nu ook de naam terug van de leerkracht/leerling die de question message heeft gepost.
Het leek me ook handig om de rol van de user te zien dus dat krijg je er ook bij. 
Je krijgt nu een array van objecten die er zo uitzien: 
![image](https://github.com/user-attachments/assets/4401190b-7815-46a1-a95f-83233423b870)

De grote hoeveelheid aanpassingen is gewoon door prettier (we delen best eens onze prettier config zodat het bij iedereen hetzelfde is). De echte aanpassingen zijn dus enkel de relatie met `User` en `QuestionMessage` in het prisma schema, en de prisma query in `getQuestionMessages`.

In de issue stond dat het niet nodig was om het databankschema aan te passen, maar dat leek me eigenlijk de beste manier, dus ik heb het toch zo gedaan. 


