### PR TITLE
Enhancement/testen voor error handling backend

### DIFF
--- a/dwengo_backend/controllers/student/studentAssignmentController.ts
+++ b/dwengo_backend/controllers/student/studentAssignmentController.ts
@@ -68,7 +68,7 @@ export const getStudentAssignmentsInClass = asyncHandler(
     // Haal standaard 5 assignments op, andere hoeveelheden kunnen ook
 
     if (limit <= 0) {
-      throw new BadRequestError("Limit wasn't a valid number.");
+      throw new BadRequestError("Limit must be a positive number.");
     }
 
     const assignments: Assignment[] = await getAssignmentsForStudentInClass(

--- a/dwengo_backend/controllers/student/studentAssignmentController.ts
+++ b/dwengo_backend/controllers/student/studentAssignmentController.ts
@@ -36,7 +36,9 @@ export const getStudentAssignments = asyncHandler(
     const limit: number = Number(req.query.limit) || 5;
     // Haal standaard 5 assignments op, andere hoeveelheden kunnen ook
 
-    if (isNaN(limit) || limit <= 0) {
+    console.log("Limit: ", limit);
+
+    if (limit <= 0) {
       throw new BadRequestError("Limit must be a positive number.");
     }
 

--- a/dwengo_backend/controllers/student/studentAssignmentController.ts
+++ b/dwengo_backend/controllers/student/studentAssignmentController.ts
@@ -36,8 +36,6 @@ export const getStudentAssignments = asyncHandler(
     const limit: number = Number(req.query.limit) || 5;
     // Haal standaard 5 assignments op, andere hoeveelheden kunnen ook
 
-    console.log("Limit: ", limit);
-
     if (limit <= 0) {
       throw new BadRequestError("Limit must be a positive number.");
     }
@@ -69,7 +67,7 @@ export const getStudentAssignmentsInClass = asyncHandler(
     const limit: number = Number(req.query.limit) || 5;
     // Haal standaard 5 assignments op, andere hoeveelheden kunnen ook
 
-    if (isNaN(limit) || limit <= 0) {
+    if (limit <= 0) {
       throw new BadRequestError("Limit wasn't a valid number.");
     }
 

--- a/dwengo_backend/routes/class/teacherClassRoutes.ts
+++ b/dwengo_backend/routes/class/teacherClassRoutes.ts
@@ -43,7 +43,7 @@ router.patch("/:classId", updateClassroom);
 
 /**
  * @route GET /class/teacher/student
- * @description Get all students in all classroom
+ * @description Get all students in all classrooms
  * @param classId: number
  * @access Teacher
  */

--- a/dwengo_backend/services/referenceValidationService.ts
+++ b/dwengo_backend/services/referenceValidationService.ts
@@ -139,7 +139,7 @@ export default class ReferenceValidationService {
     } else {
       if (!localId) {
         throw new BadRequestError(
-          "Missing localId voor niet-externe leerpadvalidatie",
+          "Missing localId for local learning path validation.",
         );
       }
       await this.validateLocalLearningPath(localId);

--- a/dwengo_backend/tests/assignment.test.ts
+++ b/dwengo_backend/tests/assignment.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { Assignment, Teacher, User } from "@prisma/client";
+import { Assignment, Class, Teacher, User } from "@prisma/client";
 import app from "../index";
-import { createTeacher } from "./helpers/testDataCreation";
+import {
+  addTeacherToClass,
+  createAssignment,
+  createClass,
+  createTeacher,
+} from "./helpers/testDataCreation";
 import request from "supertest";
 import prisma from "./helpers/prisma";
 
@@ -13,9 +18,33 @@ const getAuthHeaders = (
 
 describe("Assignment test", (): void => {
   let teacherUser1: User & { teacher: Teacher; token: string };
+  let teacherUser2: User & { teacher: Teacher; token: string };
+  let assignment1: Assignment;
+  let class1: Class;
+  const learningPathId = "Leerpad";
+  const title = "Nieuwe taak";
+  const description = "beschrijving";
+  const deadline = new Date("2025-05-28");
 
   beforeEach(async (): Promise<void> => {
     teacherUser1 = await createTeacher("Bob", "Boons", "bob.boons@gmail.com");
+    teacherUser2 = await createTeacher(
+      "Kathleen",
+      "Aerts",
+      "alice.aerts@gmail.com",
+    );
+
+    class1 = await createClass("LAWI", "code");
+
+    await addTeacherToClass(teacherUser2.id, class1.id);
+
+    assignment1 = await createAssignment(
+      class1.id,
+      learningPathId,
+      title,
+      description,
+      deadline,
+    );
   });
 
   describe("[GET] /assignment/:assignmentId", (): void => {
@@ -34,6 +63,18 @@ describe("Assignment test", (): void => {
         where: { id: nonExistentId },
       });
       expect(assignment).toBeNull();
+    });
+
+    it("should return the assignment when it is found", async (): Promise<void> => {
+      const { status, body } = await request(app)
+        .get(`/assignment/${assignment1.id}}`)
+        .set(getAuthHeaders(teacherUser1));
+
+      expect(status).toBe(200);
+      expect(body.title).toBe(title);
+      expect(new Date(body.deadline)).toStrictEqual(deadline);
+      expect(body.pathRef).toBe(learningPathId);
+      expect(body.description).toBe(description);
     });
   });
 });

--- a/dwengo_backend/tests/auth.test.ts
+++ b/dwengo_backend/tests/auth.test.ts
@@ -265,6 +265,54 @@ describe("Authentication API Tests", () => {
         ]),
       );
     });
+    it("should fail if a teacher wants to log in as a student", async () => {
+      const teacherMail = "teacher90@example.com";
+      const teacherPW = "password123";
+      // Register teacher
+      const res = await request(app).post("/auth/teacher/register").send({
+        firstName: "Peter",
+        lastName: "Petersen",
+        email: teacherMail,
+        password: teacherPW,
+      });
+      expect(res.status).toBe(201);
+
+      const { status, body } = await request(app)
+        .post("/auth/student/login")
+        .send({
+          email: teacherMail,
+          password: teacherPW,
+        });
+
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe("Teacher cannot login as student.");
+    });
+    it("should fail if admin wants to login as a student", async () => {
+      // register admin
+      const adminMail = "admin@admin.com";
+      const adminPW = "admin";
+      await prisma.user.create({
+        data: {
+          firstName: "admin",
+          lastName: "admin",
+          email: adminMail,
+          password: adminPW,
+          role: "ADMIN",
+        },
+      });
+
+      const { status, body } = await request(app)
+        .post("/auth/student/login")
+        .send({
+          email: adminMail,
+          password: adminPW,
+        });
+
+      expect(status).toBe(404);
+      expect(body.error).toBe("NotFoundError");
+      expect(body.message).toBe("Student not found.");
+    });
   });
 
   // same test cases as for student, but now for teacher routes
@@ -523,6 +571,54 @@ describe("Authentication API Tests", () => {
           }),
         ]),
       );
+    });
+    it("should fail if a student wants to log in as a teacher", async () => {
+      const studentMail = "student90@example.com";
+      const studentPW = "password123";
+      // Register teacher
+      const res = await request(app).post("/auth/student/register").send({
+        firstName: "Peter",
+        lastName: "Petersen",
+        email: studentMail,
+        password: studentPW,
+      });
+      expect(res.status).toBe(201);
+
+      const { status, body } = await request(app)
+        .post("/auth/teacher/login")
+        .send({
+          email: studentMail,
+          password: studentPW,
+        });
+
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe("Student cannot login as teacher.");
+    });
+    it("should fail if admin wants to login as a teacher", async () => {
+      // register admin
+      const adminMail = "admin@admin.com";
+      const adminPW = "admin";
+      await prisma.user.create({
+        data: {
+          firstName: "admin",
+          lastName: "admin",
+          email: adminMail,
+          password: adminPW,
+          role: "ADMIN",
+        },
+      });
+
+      const { status, body } = await request(app)
+        .post("/auth/teacher/login")
+        .send({
+          email: adminMail,
+          password: adminPW,
+        });
+
+      expect(status).toBe(404);
+      expect(body.error).toBe("NotFoundError");
+      expect(body.message).toBe("Teacher not found.");
     });
   });
 });

--- a/dwengo_backend/tests/invite.test.ts
+++ b/dwengo_backend/tests/invite.test.ts
@@ -7,6 +7,7 @@ import {
   ClassTeacher,
   Invite,
   JoinRequestStatus,
+  Student,
   Teacher,
   User,
 } from "@prisma/client";
@@ -14,6 +15,7 @@ import {
   addTeacherToClass,
   createClass,
   createInvite,
+  createStudent,
   createTeacher,
 } from "./helpers/testDataCreation";
 
@@ -234,6 +236,49 @@ describe("invite tests", async (): Promise<void> => {
       );
 
       // verify no invite was created
+      await prisma.invite.findMany().then((invites: Invite[]): void => {
+        expect(invites.length).toBe(0);
+      });
+    });
+
+    it("should respond with a `404` status code when the teacher does not exist", async (): Promise<void> => {
+      await addTeacherToClass(teacherUser1.id, classroom.id);
+      const { status, body } = await request(app)
+        .post(`/invite/class/${classroom.id}`)
+        .set("Authorization", `Bearer ${teacherUser1.token}`)
+        .send({
+          otherTeacherEmail: "ikbestaniet@gmail.com",
+        });
+
+      expect(body.message).toBe(
+        "Given email doesn't correspond to any existing teachers.",
+      );
+      expect(status).toBe(404);
+      expect(body.error).toBe("NotFoundError");
+      // verify that no invite was created
+      await prisma.invite.findMany().then((invites: Invite[]): void => {
+        expect(invites.length).toBe(0);
+      });
+    });
+
+    it("should respond with a `401` status code when the teacher does not exist", async (): Promise<void> => {
+      await addTeacherToClass(teacherUser1.id, classroom.id);
+
+      const student: User & { student: Student; token: string } =
+        await createStudent("new", "student", "newstudent@gmail.com");
+      const { status, body } = await request(app)
+        .post(`/invite/class/${classroom.id}`)
+        .set("Authorization", `Bearer ${teacherUser1.token}`)
+        .send({
+          otherTeacherEmail: student.email,
+        });
+
+      expect(body.message).toBe(
+        "User is not a teacher. Only teachers can receive invites.",
+      );
+      expect(status).toBe(401);
+      expect(body.error).toBe("UnauthorizedError");
+      // verify that no invite was created
       await prisma.invite.findMany().then((invites: Invite[]): void => {
         expect(invites.length).toBe(0);
       });
@@ -542,6 +587,25 @@ describe("invite tests", async (): Promise<void> => {
           }),
         ]),
       );
+    });
+
+    it("should not delete the invite if a teacher that is not part of the class tries it", async (): Promise<void> => {
+      const teacherUser3: User & { teacher: Teacher; token: string } =
+        await createTeacher("Jane", "Doe", "jane.doe@gmail.com");
+      const { status, body } = await request(app)
+        .delete(`/invite/${invite.inviteId}/class/${classroom.id}`)
+        .set("Authorization", `Bearer ${teacherUser3.token}`); // not part of the class
+
+      expect(status).toBe(403);
+      expect(body.error).toBe("AccessDeniedError");
+      expect(body.message).toBe("Teacher is not a part of this class.");
+      // verify that the invite was not deleted
+      const checkInvite: Invite | null = await prisma.invite.findUnique({
+        where: {
+          inviteId: invite.inviteId,
+        },
+      });
+      expect(checkInvite).toStrictEqual(invite);
     });
   });
 

--- a/dwengo_backend/tests/joinRequest.test.ts
+++ b/dwengo_backend/tests/joinRequest.test.ts
@@ -282,6 +282,72 @@ describe("join request tests", async (): Promise<void> => {
         classroom,
       );
     });
+
+    it("should respond with a `404` status code when the join request does not exist", async (): Promise<void> => {
+      // let's delete the join request and then try denying it
+      await prisma.joinRequest.delete({
+        where: {
+          requestId: joinRequest.requestId,
+        },
+      });
+      await denyAndVerifyJoinRequest();
+    });
+
+    it("should respond with a `404` status code when the join request is not pending", async (): Promise<void> => {
+      // update the status of the join request to approved
+      await prisma.joinRequest.update({
+        where: {
+          requestId: joinRequest.requestId,
+        },
+        data: {
+          status: JoinRequestStatus.APPROVED,
+        },
+      });
+      // now let's try approving it
+      await denyAndVerifyJoinRequest();
+    });
+
+    async function denyAndVerifyJoinRequest(): Promise<void> {
+      const { status, body } = await request(app)
+        .patch(
+          `/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
+        )
+        .set("Authorization", `Bearer ${teacherUser1.token}`) // teacherUser1 is a teacher of the class
+        .send({
+          action: "approve",
+        });
+
+      expect(status).toBe(404);
+      expect(body.error).toBe("NotFoundError");
+      expect(body.message).toBe(
+        "Join request for this class is not found or is not pending.",
+      );
+    }
+
+    it("should respond with a `403` status code when the teacher is not allowed to approve/deny the request", async (): Promise<void> => {
+      // create teacher that's not part of the class
+      const teacherUser2: User & { teacher: Teacher; token: string } =
+        await createTeacher("bleep", "blop", "bleep.blop@gmail.com");
+      // try having teacherUser2 approve the join request
+      const { status, body } = await request(app)
+        .patch(
+          `/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
+        )
+        .set("Authorization", `Bearer ${teacherUser2.token}`) // teacherUser2 is not a teacher of the class
+        .send({
+          action: "deny",
+        });
+
+      expect(status).toBe(403);
+      expect(body.error).toBe("AccessDeniedError");
+      expect(body.message).toBe("Teacher is not a part of this class.");
+
+      await verifyJoinRequestNotUpdatedStudentNotAdded(
+        joinRequest,
+        studentUser1,
+        classroom,
+      );
+    });
   });
 
   describe("[GET] /join-request/teacher/class/:classId", async (): Promise<void> => {
@@ -302,7 +368,7 @@ describe("join request tests", async (): Promise<void> => {
       expectBodyToHaveListOfJoinRequest(body);
     });
 
-    it("should respond with a `400` status code when the teacher is not allowed to view the join requests", async (): Promise<void> => {
+    it("should respond with a `403` status code when the teacher is not allowed to view the join requests", async (): Promise<void> => {
       // create teacher that's not part of the class
       const teacherUser2: User & { teacher: Teacher; token: string } =
         await createTeacher("Hi", "Ho", "hiho@gmail.com");

--- a/dwengo_backend/tests/studentAssignment.test.ts
+++ b/dwengo_backend/tests/studentAssignment.test.ts
@@ -300,6 +300,29 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
       expect(status).toBe(200);
       expect(body).toHaveLength(2);
     });
+
+    it("should respond with a `400` status code because the limit is negative.", async (): Promise<void> => {
+      const { status, body } = await request(app)
+        .get("/assignment/student")
+        .query({ limit: -5 })
+        .set("Authorization", `Bearer ${student5.token}`);
+
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe("Limit must be a positive number.");
+    });
+
+    it("should respond with a `400` status code because the limit is not a number.", async (): Promise<void> => {
+      const { status, body } = await request(app)
+        .get("/assignment/student")
+        .query({ limit: "limit" })
+        .set("Authorization", `Bearer ${student5.token}`);
+
+      stringToDate(body, 2);
+
+      expect(status).toBe(200);
+      expect(body).toHaveLength(2);
+    });
   });
 
   describe("GET /assignment/student/class/:classId", async (): Promise<void> => {
@@ -459,6 +482,29 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
     const { status, body } = await request(app)
       .get(`/assignment/student/class/${class3.id}`)
       .query({ limit: 10 })
+      .set("Authorization", `Bearer ${student5.token}`);
+
+    stringToDate(body, 2);
+
+    expect(status).toBe(200);
+    expect(body).toHaveLength(2);
+  });
+
+  it("should respond with a `400` status code because the limit is negative.", async (): Promise<void> => {
+    const { status, body } = await request(app)
+      .get(`/assignment/student/class/${class3.id}`)
+      .query({ limit: -5 })
+      .set("Authorization", `Bearer ${student5.token}`);
+
+    expect(status).toBe(400);
+    expect(body.error).toBe("BadRequestError");
+    expect(body.message).toBe("Limit must be a positive number.");
+  });
+
+  it("should respond with a `400` status code because the limit is not a number.", async (): Promise<void> => {
+    const { status, body } = await request(app)
+      .get(`/assignment/student/class/${class3.id}`)
+      .query({ limit: "limit" })
       .set("Authorization", `Bearer ${student5.token}`);
 
     stringToDate(body, 2);

--- a/dwengo_backend/tests/submissions.test.ts
+++ b/dwengo_backend/tests/submissions.test.ts
@@ -115,18 +115,6 @@ describe("Submission tests", (): void => {
     });
   });
 
-  describe("[GET] /submission/student/:studentId", (): void => {
-    it("Should respond with a `401` status code because a teacher is unauthorized", async (): Promise<void> => {
-      const { status, body } = await request(app)
-        .get(`/submission/student/${studentId}`)
-        .set("Authorization", `Bearer ${teacher.token}`);
-
-      expect(status).toBe(401);
-      expect(body.error).toBe("UnauthorizedError");
-      expect(body.message).toBe("Not a valid student.");
-    });
-  });
-
   describe("[GET] /submission/student/assignment/:assignmentId/evaluation/:evaluationId", (): void => {
     it("Should respond with a `200` status code and return the submission for an evaluation", async (): Promise<void> => {
       const { status, body } = await request(app)

--- a/dwengo_backend/tests/teacherAssignment.test.ts
+++ b/dwengo_backend/tests/teacherAssignment.test.ts
@@ -2,12 +2,20 @@ import { beforeEach, describe, expect, it } from "vitest";
 import request from "supertest";
 import prisma from "./helpers/prisma";
 import app from "../index";
-import { Assignment, Class, LearningPath, Teacher, User } from "@prisma/client";
+import {
+  Assignment,
+  Class,
+  LearningPath,
+  Student,
+  Teacher,
+  User,
+} from "@prisma/client";
 import {
   addTeacherToClass,
   createAssignment,
   createClass,
   createLearningPath,
+  createStudent,
   createTeacher,
   stringToDate,
 } from "./helpers/testDataCreation";
@@ -16,6 +24,8 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
   let teacher1: User & { teacher: Teacher; token: string };
   let teacher2: User & { teacher: Teacher; token: string };
   let teacher3: User & { teacher: Teacher; token: string };
+
+  let student: User & { student: Student; token: string };
 
   let class1: Class;
   let class2: Class;
@@ -43,6 +53,8 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
       "Ceulemans",
       "charlie.ceulemans@gmail.com",
     );
+
+    student = await createStudent("Daan", "De Bruyn", "daan@gmail.com");
     // create some learning paths
     lp1 = await createLearningPath(
       "LP1",
@@ -114,6 +126,24 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
       expect(body.assignment.pathRef).toBe(lp1.id);
     });
 
+    it("should respond with a `401` status code because a student is not allowed to perform this action", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .post("/assignment/teacher")
+        .set("Authorization", `Bearer ${student.token}`)
+        .send({
+          classId: class3.id,
+          pathRef: lp1.id,
+          deadline: "2026-10-23",
+          pathLanguage: "nl",
+          title: "Learning Path 1",
+          description: "description1",
+        });
+      expect(status).toBe(401);
+      expect(body.error).toBe("UnauthorizedError");
+      expect(body.message).toBe("Not a valid teacher.");
+    });
+
     it("should respond with a `403` status code because the teacher is not a member of the class", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
@@ -130,6 +160,87 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
       expect(status).toBe(403);
       expect(body.error).toBe("AccessDeniedError");
       expect(body.message).toBe("Teacher does not teach this class.");
+    });
+
+    it("should respond with a `400` status code because there is no language given", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .post("/assignment/teacher")
+        .set("Authorization", `Bearer ${teacher1.token}`)
+        .send({
+          classId: class3.id,
+          pathRef: lp1.id,
+          deadline: "2026-10-23",
+          title: "Learning Path 1",
+          description: "description1",
+          teamSize: 2,
+          isExternal: true,
+        });
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe(
+        "Missing Dwengo leerpad references (hruid/language).",
+      );
+    });
+
+    it("should respond with a `400` status code because there is no pathRef given", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .post("/assignment/teacher")
+        .set("Authorization", `Bearer ${teacher1.token}`)
+        .send({
+          classId: class3.id,
+          deadline: "2026-10-23",
+          title: "Learning Path 1",
+          description: "description1",
+          pathLanguage: "nl",
+          teamSize: 2,
+          isExternal: true,
+        });
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe(
+        "Missing Dwengo leerpad references (hruid/language).",
+      );
+    });
+
+    it("should respond with a `400` status code because there is no localId given", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .post("/assignment/teacher")
+        .set("Authorization", `Bearer ${teacher1.token}`)
+        .send({
+          classId: class3.id,
+          deadline: "2026-10-23",
+          title: "Learning Path 1",
+          description: "description1",
+          pathLanguage: "nl",
+          teamSize: 2,
+        });
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe(
+        "Missing localId for local learning path validation.",
+      );
+    });
+
+    it("should respond with a `404` status code because there is no existing localId given", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .post("/assignment/teacher")
+        .set("Authorization", `Bearer ${teacher1.token}`)
+        .send({
+          classId: class3.id,
+          deadline: "2026-10-23",
+          title: "Learning Path 1",
+          description: "description1",
+          pathLanguage: "nl",
+          pathRef: "nonExistingId",
+          teamSize: 2,
+        });
+      expect(status).toBe(404);
+      expect(body.error).toBe("NotFoundError");
+      expect(body.message).toBe("Learning path not found.");
     });
   });
 
@@ -213,6 +324,24 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
       );
     });
 
+    it("should respond with a `403` status code because the teacher has no classes", async (): Promise<void> => {
+      const newTeacher = await createTeacher(
+        "David",
+        "De Bruyn",
+        "david@gmail.com",
+      );
+      const { status, body } = await request(app)
+        .patch(`/assignment/teacher/${assignment1.id}`)
+        .set("Authorization", `Bearer ${newTeacher.token}`)
+        .send({
+          learningPathId: lp2.id,
+        });
+
+      expect(status).toBe(403);
+      expect(body.error).toBe("AccessDeniedError");
+      expect(body.message).toBe("This teacher teaches no classes.");
+    });
+
     it("should respond with a `404` status code because the teacher is not a member of the class", async (): Promise<void> => {
       // First create assignment for class3
       await request(app)
@@ -236,6 +365,88 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
       expect(body.message).toBe(
         "No classes of this teacher have this assignment.",
       );
+    });
+
+    it("should respond with a `400` status code because there is no language given", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .patch(`/assignment/teacher/${assignment1.id}`)
+        .set("Authorization", `Bearer ${teacher2.token}`)
+        .send({
+          classId: class3.id,
+          pathRef: lp1.id,
+          deadline: "2026-10-23",
+          title: "Learning Path 1",
+          description: "description1",
+          teamSize: 2,
+          isExternal: true,
+        });
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe(
+        "Missing Dwengo leerpad references (hruid/language).",
+      );
+    });
+
+    it("should respond with a `400` status code because there is no pathRef given", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .patch(`/assignment/teacher/${assignment1.id}`)
+        .set("Authorization", `Bearer ${teacher2.token}`)
+        .send({
+          classId: class3.id,
+          deadline: "2026-10-23",
+          title: "Learning Path 1",
+          description: "description1",
+          pathLanguage: "nl",
+          teamSize: 2,
+          isExternal: true,
+        });
+      console.log(body);
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe(
+        "Missing Dwengo leerpad references (hruid/language).",
+      );
+    });
+
+    it("should respond with a `400` status code because there is no localId given", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .patch(`/assignment/teacher/${assignment1.id}`)
+        .set("Authorization", `Bearer ${teacher2.token}`)
+        .send({
+          classId: class3.id,
+          deadline: "2026-10-23",
+          title: "Learning Path 1",
+          description: "description1",
+          pathLanguage: "nl",
+          teamSize: 2,
+        });
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe(
+        "Missing localId for local learning path validation.",
+      );
+    });
+
+    it("should respond with a `404` status code because there is no existing localId given", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .patch(`/assignment/teacher/${assignment1.id}`)
+        .set("Authorization", `Bearer ${teacher2.token}`)
+        .send({
+          classId: class3.id,
+          deadline: "2026-10-23",
+          title: "Learning Path 1",
+          description: "description1",
+          pathLanguage: "nl",
+          pathRef: "nonExistingId",
+          teamSize: 2,
+        });
+      expect(status).toBe(404);
+      expect(body.error).toBe("NotFoundError");
+      expect(body.message).toBe("Learning path not found.");
     });
   });
 
@@ -263,6 +474,24 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
       expect(body.message).toBe(
         "No classes of this teacher have this assignment.",
       );
+    });
+
+    it("should respond with a `401` status code because a student is not allowed to perform this action", async (): Promise<void> => {
+      // class3 has no assignments
+      const { status, body } = await request(app)
+        .delete(`/assignment/teacher/${assignment1.id}`)
+        .set("Authorization", `Bearer ${student.token}`)
+        .send({
+          classId: class3.id,
+          pathRef: lp1.id,
+          deadline: "2026-10-23",
+          pathLanguage: "nl",
+          title: "Learning Path 1",
+          description: "description1",
+        });
+      expect(status).toBe(401);
+      expect(body.error).toBe("UnauthorizedError");
+      expect(body.message).toBe("Not a valid teacher.");
     });
   });
 


### PR DESCRIPTION
In deze pull request ga ik meer testen toevoegen om alle error handling te testen. Ik zal hiervoor de bestaande testen uitbreiden zodat alle errors die een route kan opwerpen getest worden. Ik zal proberen of ik ook prisma errors kan simuleren, maar weet nog niet of dit zal lukken. 

## Aanpassingen:
- *assignment.test.ts*: 1 test toegevoegd.
- *auth.test.ts*: 4 testen toegevoegd.
- *class.test.ts*: 5 testen toegevoegd. 1 van de testen staat nog in commentaar. Deze kan pas uitgecommentarieerd worden als #310 is opgelost.
- *feedback.test.ts*: 5 testen toegevoegd.
- *invite.test.ts*: 3 testen toegevoegd.
- *joinRequest.test.ts*: 3 testen toegevoegd.
- *studentAssignment.test.ts*: 4 testen toegevoegd. Hier heb ik ook de error messages uniform gemaakt naar
```typescript
"Limit must be a positive number."
```
Ook de onnodige conditie 
```typescript
isNaN(limit)
```
is weg. Dit werd opgevangen door 
```typescript
Number(req.query.limit) || 5;
```

- *submissions.test.ts*: 1 test verwijderd. Deze test verwees naar een onbestaande route.
- *teacherAssignment.test.ts*: 11 testen toegevoegd.

## Belangrijk
De rest van de error functies zullen best als unit testen nog getest worden. Op die manier zouden er volgens mij ook Prisma errors kunnen opgegooid worden.