### PR TITLE
Input validatie aan de hand van Zodschemas

### DIFF
--- a/dwengo_backend/controllers/student/studentClassController.ts
+++ b/dwengo_backend/controllers/student/studentClassController.ts
@@ -7,7 +7,7 @@ import { getUserFromAuthRequest } from "../../helpers/getUserFromAuthRequest";
 /**
  * Get all classes that a student is partaking in
  * @route GET /student/classes
- * returns a list of all classes the student is partaking in in the response body
+ * returns a list of all classes the student is partaking in the response body
  */
 export const getStudentClasses = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {

--- a/dwengo_backend/controllers/student/studentClassController.ts
+++ b/dwengo_backend/controllers/student/studentClassController.ts
@@ -20,7 +20,7 @@ export const getStudentClasses = asyncHandler(
 export const getStudentClassById = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const studentId: number = getUserFromAuthRequest(req).id;
-    const classId: number = parseInt(req.params.classId);
+    const classId = req.params.classId as unknown as number;
     const classgroup = await classService.getStudentClassByClassId(
       studentId,
       classId,
@@ -32,7 +32,7 @@ export const getStudentClassById = asyncHandler(
 export const leaveClass = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const studentId: number = getUserFromAuthRequest(req).id;
-    const classId: number = parseInt(req.params.classId);
+    const classId = req.params.classId as unknown as number;
 
     await classService.leaveClassAsStudent(studentId, classId);
     res.status(204).end();

--- a/dwengo_backend/controllers/teacher/teacherClassController.ts
+++ b/dwengo_backend/controllers/teacher/teacherClassController.ts
@@ -1,6 +1,6 @@
 import asyncHandler from "express-async-handler";
 import { Response } from "express";
-import { AuthenticatedRequest } from "../../middleware/authMiddleware/teacherAuthMiddleware";
+import { AuthenticatedRequest } from "../../interfaces/extendedTypeInterfaces";
 import classService from "../../services/classService";
 import { Student } from "@prisma/client";
 import { getUserFromAuthRequest } from "../../helpers/getUserFromAuthRequest";
@@ -52,10 +52,10 @@ export const createClassroom = asyncHandler(
  */
 export const deleteClassroom = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-    const { classId } = req.params;
-    const teacherId = getUserFromAuthRequest(req).id;
+    const classId: number = req.params.classId as unknown as number;
+    const teacherId: number = getUserFromAuthRequest(req).id;
 
-    await classService.deleteClass(Number(classId), teacherId);
+    await classService.deleteClass(classId, teacherId);
     res.status(204).end();
   },
 );
@@ -67,7 +67,7 @@ export const deleteClassroom = asyncHandler(
 export const updateClassroom = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     const { name } = req.body;
-    const classId: number = parseInt(req.params.classId);
+    const classId: number = req.params.classId as unknown as number;
     const teacherId: number = getUserFromAuthRequest(req).id;
 
     isNameValid(req); // if invalid, an error is thrown
@@ -83,10 +83,10 @@ export const updateClassroom = asyncHandler(
  */
 export const getJoinLink = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-    const { classId } = req.params;
-    const teacherId = getUserFromAuthRequest(req).id;
+    const classId: number = req.params.classId as unknown as number;
+    const teacherId: number = getUserFromAuthRequest(req).id;
 
-    const joinCode = await classService.getJoinCode(Number(classId), teacherId);
+    const joinCode: string = await classService.getJoinCode(classId, teacherId);
 
     const joinLink = `${APP_URL}/join-request/student/join?joinCode=${joinCode}`;
     res.status(200).json({ joinLink });
@@ -99,10 +99,10 @@ export const getJoinLink = asyncHandler(
  */
 export const regenerateJoinLink = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-    const { classId } = req.params;
-    const teacherId = getUserFromAuthRequest(req).id;
-    const newJoinCode = await classService.regenerateJoinCode(
-      Number(classId),
+    const classId: number = req.params.classId as unknown as number;
+    const teacherId: number = getUserFromAuthRequest(req).id;
+    const newJoinCode: string = await classService.regenerateJoinCode(
+      classId,
       teacherId,
     );
     const joinLink = `${APP_URL}/join-request/student/join?joinCode=${newJoinCode}`;
@@ -131,11 +131,11 @@ export const getClassroomsStudents = asyncHandler(
  */
 export const getStudentsByClassId = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-    const { classId } = req.params;
-    const teacherId = getUserFromAuthRequest(req).id;
+    const classId: number = req.params.classId as unknown as number;
+    const teacherId: number = getUserFromAuthRequest(req).id;
 
     const students: Student[] = await classService.getStudentsByClass(
-      Number(classId),
+      classId,
       teacherId,
     );
 
@@ -168,7 +168,7 @@ export const getAllClassrooms = asyncHandler(
  */
 export const getClassByIdAndTeacherId = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-    const classId: number = parseInt(req.params.classId);
+    const classId: number = req.params.classId as unknown as number;
     const teacherId: number = getUserFromAuthRequest(req).id;
 
     const classroom = await classService.getClassByIdAndTeacherId(

--- a/dwengo_backend/errors/errors.ts
+++ b/dwengo_backend/errors/errors.ts
@@ -1,9 +1,14 @@
 export class AppError extends Error {
   public statusCode: number;
-  constructor(message: string, statusCode: number) {
+  public details?: unknown;
+
+  constructor(message: string, statusCode: number, details?: unknown) {
     super(message);
     this.name = this.constructor.name;
     this.statusCode = statusCode;
+    this.details = details;
+
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 
@@ -26,8 +31,8 @@ export class ForbiddenActionError extends AppError {
 }
 
 export class BadRequestError extends AppError {
-  constructor(message: string) {
-    super(message, 400);
+  constructor(message: string, details?: unknown) {
+    super(message, 400, details);
   }
 }
 

--- a/dwengo_backend/middleware/errorMiddleware.ts
+++ b/dwengo_backend/middleware/errorMiddleware.ts
@@ -13,6 +13,7 @@ const errorHandler = (
     res.status(err.statusCode).json({
       error: err.name,
       message: err.message,
+      details: err.details,
     });
   } else {
     const statusCode = res.statusCode === 200 ? 500 : res.statusCode;

--- a/dwengo_backend/middleware/validateRequest.ts
+++ b/dwengo_backend/middleware/validateRequest.ts
@@ -3,6 +3,7 @@ import { z, ZodIssue } from "zod";
 import { AuthenticatedRequest } from "../interfaces/extendedTypeInterfaces";
 import { ParsedQs } from "qs";
 import { ParamsDictionary } from "express-serve-static-core";
+import { BadRequestError } from "../errors/errors";
 
 const formatZodErrors = (error: z.ZodError, source: string) => {
   return error.issues.map((issue: ZodIssue) => ({
@@ -78,12 +79,10 @@ export const validateRequest =
     }
 
     if (error_details.length > 0) {
-      res.status(400).json({
-        error: validationErrorMessage,
-        message: customErrorMessage || "Invalid request body/params/query",
-        details: error_details,
-      });
-      return;
+      throw new BadRequestError(
+        customErrorMessage || "Invalid request body/params/query",
+        error_details,
+      );
     }
 
     next();

--- a/dwengo_backend/middleware/validateRequest.ts
+++ b/dwengo_backend/middleware/validateRequest.ts
@@ -1,6 +1,8 @@
 import { Response, NextFunction } from "express";
 import { z, ZodIssue } from "zod";
-import { AuthenticatedRequest } from "./authMiddleware/teacherAuthMiddleware";
+import { AuthenticatedRequest } from "../interfaces/extendedTypeInterfaces";
+import { ParsedQs } from "qs";
+import { ParamsDictionary } from "express-serve-static-core";
 
 const formatZodErrors = (error: z.ZodError, source: string) => {
   return error.issues.map((issue: ZodIssue) => ({
@@ -54,18 +56,24 @@ export const validateRequest =
       const bodyResult = bodySchema.safeParse(req.body);
       if (!bodyResult.success) {
         error_details.push(...formatZodErrors(bodyResult.error, "body"));
+      } else {
+        req.body = bodyResult.data;
       }
     }
     if (paramsSchema) {
       const paramsResult = paramsSchema.safeParse(req.params);
       if (!paramsResult.success) {
         error_details.push(...formatZodErrors(paramsResult.error, "params"));
+      } else if (paramsResult.data) {
+        req.params = paramsResult.data as unknown as ParamsDictionary;
       }
     }
     if (querySchema) {
       const queryResult = querySchema.safeParse(req.query);
       if (!queryResult.success) {
         error_details.push(...formatZodErrors(queryResult.error, "query"));
+      } else {
+        req.query = queryResult.data as unknown as ParsedQs;
       }
     }
 

--- a/dwengo_backend/routes/class/classRoutes.ts
+++ b/dwengo_backend/routes/class/classRoutes.ts
@@ -3,6 +3,7 @@ import studentClassRoutes from "./studentClassRoutes";
 import teacherClassRoutes from "./teacherClassRoutes";
 
 const router = Router();
+
 router.use("/student", studentClassRoutes);
 router.use("/teacher", teacherClassRoutes);
 

--- a/dwengo_backend/routes/class/classRoutes.ts
+++ b/dwengo_backend/routes/class/classRoutes.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import studentClassRoutes from "./studentClassRoutes";
 import teacherClassRoutes from "./teacherClassRoutes";
 
-const router = Router();
+const router: Router = Router();
 
 router.use("/student", studentClassRoutes);
 router.use("/teacher", teacherClassRoutes);

--- a/dwengo_backend/routes/class/studentClassRoutes.ts
+++ b/dwengo_backend/routes/class/studentClassRoutes.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { Router } from "express";
 import { protectStudent } from "../../middleware/authMiddleware/studentAuthMiddleware";
 import {
   getStudentClassById,
@@ -8,7 +8,7 @@ import {
 import { validateRequest } from "../../middleware/validateRequest";
 import { classIdParamsSchema } from "../../zodSchemas/studentClassSchemas/classIdSchema";
 
-const router = express.Router();
+const router: Router = express.Router();
 router.use(protectStudent);
 
 /**

--- a/dwengo_backend/routes/class/studentClassRoutes.ts
+++ b/dwengo_backend/routes/class/studentClassRoutes.ts
@@ -5,6 +5,8 @@ import {
   getStudentClasses,
   leaveClass,
 } from "../../controllers/student/studentClassController";
+import { validateRequest } from "../../middleware/validateRequest";
+import { classIdParamsSchema } from "../../zodSchemas/studentClassSchemas/classIdSchema";
 
 const router = express.Router();
 router.use(protectStudent);
@@ -22,7 +24,14 @@ router.get("/", getStudentClasses);
  * @param classId: number
  * @access Student
  */
-router.get("/:classId", getStudentClassById);
+router.get(
+  "/:classId",
+  validateRequest({
+    paramsSchema: classIdParamsSchema,
+    customErrorMessage: "invalid classId request params",
+  }),
+  getStudentClassById,
+);
 
 /**
  * @route DELETE /class/student/:classId
@@ -30,6 +39,13 @@ router.get("/:classId", getStudentClassById);
  * @param classId: number
  * @access Student
  */
-router.delete("/:classId", leaveClass);
+router.delete(
+  "/:classId",
+  validateRequest({
+    paramsSchema: classIdParamsSchema,
+    customErrorMessage: "invalid classId request params",
+  }),
+  leaveClass,
+);
 
-export default router;
+export default router; // exports the student class router

--- a/dwengo_backend/routes/class/teacherClassRoutes.ts
+++ b/dwengo_backend/routes/class/teacherClassRoutes.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { Router } from "express";
 import {
   createClassroom,
   deleteClassroom,
@@ -11,8 +11,10 @@ import {
   getStudentsByClassId,
 } from "../../controllers/teacher/teacherClassController";
 import { protectTeacher } from "../../middleware/authMiddleware/teacherAuthMiddleware";
+import { validateRequest } from "../../middleware/validateRequest";
+import { classIdParamsSchema } from "../../zodSchemas/studentClassSchemas/classIdSchema";
 
-const router = express.Router();
+const router: Router = express.Router();
 router.use(protectTeacher);
 
 // routes for classes
@@ -39,12 +41,18 @@ router.get("/", getTeacherClasses);
  * @body name: string
  * @access Teacher
  */
-router.patch("/:classId", updateClassroom);
+router.patch(
+  "/:classId",
+  validateRequest({
+    customErrorMessage: "invalid classId request parameter",
+    paramsSchema: classIdParamsSchema,
+  }),
+  updateClassroom,
+);
 
 /**
  * @route GET /class/teacher/student
  * @description Get all students in all classrooms
- * @param classId: number
  * @access Teacher
  */
 router.get("/student", getClassroomsStudents);
@@ -55,7 +63,14 @@ router.get("/student", getClassroomsStudents);
  * @param classId: number
  * @access Teacher
  */
-router.get("/:classId/student", getStudentsByClassId);
+router.get(
+  "/:classId/student",
+  validateRequest({
+    customErrorMessage: "invalid classId request parameter",
+    paramsSchema: classIdParamsSchema,
+  }),
+  getStudentsByClassId,
+);
 
 /**
  * @route GET /class/teacher/:classId/join-link
@@ -63,7 +78,14 @@ router.get("/:classId/student", getStudentsByClassId);
  * @param classId: string
  * @access Teacher
  */
-router.get("/:classId/join-link", getJoinLink);
+router.get(
+  "/:classId/join-link",
+  validateRequest({
+    customErrorMessage: "invalid classId request parameter",
+    paramsSchema: classIdParamsSchema,
+  }),
+  getJoinLink,
+);
 
 /**
  * @route PATCH /class/teacher/:classId/join-link
@@ -71,7 +93,14 @@ router.get("/:classId/join-link", getJoinLink);
  * @param classId: string
  * @access Teacher
  */
-router.patch("/:classId/join-link", regenerateJoinLink);
+router.patch(
+  "/:classId/join-link",
+  validateRequest({
+    customErrorMessage: "invalid classId request parameter",
+    paramsSchema: classIdParamsSchema,
+  }),
+  regenerateJoinLink,
+);
 
 /**
  * @route GET /class/teacher/:classId
@@ -79,7 +108,14 @@ router.patch("/:classId/join-link", regenerateJoinLink);
  * @param classId: string
  * @access Teacher
  */
-router.get("/:classId", getClassByIdAndTeacherId);
+router.get(
+  "/:classId",
+  validateRequest({
+    customErrorMessage: "invalid classId request parameter",
+    paramsSchema: classIdParamsSchema,
+  }),
+  getClassByIdAndTeacherId,
+);
 
 /**
  * @route DELETE /class/teacher/:classId
@@ -87,6 +123,13 @@ router.get("/:classId", getClassByIdAndTeacherId);
  * @param classId: string
  * @access Teacher
  */
-router.delete("/:classId", deleteClassroom);
+router.delete(
+  "/:classId",
+  validateRequest({
+    customErrorMessage: "invalid classId request parameter",
+    paramsSchema: classIdParamsSchema,
+  }),
+  deleteClassroom,
+);
 
 export default router;

--- a/dwengo_backend/tests/class.test.ts
+++ b/dwengo_backend/tests/class.test.ts
@@ -324,6 +324,16 @@ describe("classroom tests", (): void => {
       expect(body.joinLink).toBeUndefined();
     });
 
+    it("should respond with `400` status code for invalid classId", async (): Promise<void> => {
+      const { status, body } = await request(app)
+        .delete("/class/teacher/not-a-number")
+        .set("Authorization", `Bearer ${teacherUser1.token}`);
+
+      expect(status).toBe(400);
+      expect(body.error).toBe("BadRequestError");
+      expect(body.message).toBe("invalid classId request parameter");
+    });
+
     it("should respond with a `404` status code if the class does not exist", async (): Promise<void> => {
       // get an id that isn't used for any existing class in the database
       const maxClass: Class | null = await prisma.class.findFirst({

--- a/dwengo_backend/tests/invite.test.ts
+++ b/dwengo_backend/tests/invite.test.ts
@@ -193,9 +193,7 @@ describe("invite tests", async (): Promise<void> => {
         });
 
       expect(status).toBe(400);
-      expect(body.error).toBe(
-        "Bad request due to invalid syntax or data (validation error)",
-      );
+      expect(body.error).toBe("BadRequestError");
       expect(body.message).toBe("invalid request for invite creation");
 
       expect(body.details).toEqual(
@@ -222,9 +220,7 @@ describe("invite tests", async (): Promise<void> => {
         .send({}); // empty body
 
       expect(status).toBe(400);
-      expect(body.error).toBe(
-        "Bad request due to invalid syntax or data (validation error)",
-      );
+      expect(body.error).toBe("BadRequestError");
       expect(body.message).toBe("invalid request for invite creation");
       expect(body.details).toEqual(
         expect.arrayContaining([
@@ -379,9 +375,7 @@ describe("invite tests", async (): Promise<void> => {
         });
 
       expect(status).toBe(400);
-      expect(body.error).toBe(
-        "Bad request due to invalid syntax or data (validation error)",
-      );
+      expect(body.error).toBe("BadRequestError");
       expect(body.message).toBe("invalid request for invite update");
       expect(body.details).toEqual(
         expect.arrayContaining([
@@ -480,9 +474,7 @@ describe("invite tests", async (): Promise<void> => {
         });
 
       expect(status).toBe(400);
-      expect(body.error).toBe(
-        "Bad request due to invalid syntax or data (validation error)",
-      );
+      expect(body.error).toBe("BadRequestError");
       expect(body.message).toBe("invalid request for invite update");
       expect(body.details).toEqual(
         expect.arrayContaining([
@@ -571,9 +563,7 @@ describe("invite tests", async (): Promise<void> => {
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(400);
-      expect(body.error).toBe(
-        "Bad request due to invalid syntax or data (validation error)",
-      );
+      expect(body.error).toBe("BadRequestError");
       expect(body.message).toBe("invalid request params");
       expect(body.details).toEqual(
         expect.arrayContaining([
@@ -658,9 +648,7 @@ describe("invite tests", async (): Promise<void> => {
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(400);
-      expect(body.error).toBe(
-        "Bad request due to invalid syntax or data (validation error)",
-      );
+      expect(body.error).toBe("BadRequestError");
       expect(body.message).toBe("invalid request params");
       expect(body.details).toEqual(
         expect.arrayContaining([

--- a/dwengo_backend/zodSchemas/assignmentSchemas.ts
+++ b/dwengo_backend/zodSchemas/assignmentSchemas.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+const allowedSortFields = ["deadline", "createdAt", "updatedAt"] as const;
+
+export const studentAssignmentsQuerySchema = z.object({
+  sort: z
+    .string()
+    .optional()
+    .transform((val) => {
+      const rawFields = val?.split(",") ?? [];
+      const filtered = rawFields.filter((field) =>
+        allowedSortFields.includes(field as any),
+      );
+      return filtered.length > 0 ? filtered : ["deadline"];
+    }),
+  order: z.enum(["asc", "desc"]).default("asc"),
+  limit: z
+    .string()
+    .optional()
+    .transform((val) => Number(val ?? "5"))
+    .refine((val) => !isNaN(val) && val > 0, {
+      message: "Limit must be a number greater than 0",
+    }),
+});

--- a/dwengo_backend/zodSchemas/classSchemas.ts
+++ b/dwengo_backend/zodSchemas/classSchemas.ts
@@ -1,14 +1,26 @@
 import { z } from "zod";
 
-export const deleteClassParamsSchema = z.object({
+export const createClassBodySchema = z.object({
+  name: z
+    .string({
+      required_error: "Vul een geldige klasnaam in",
+      invalid_type_error: "Vul een geldige klasnaam in",
+    })
+    .trim()
+    .min(1, { message: "Vul een geldige klasnaam in" }),
+});
+
+export const deleteClassParamSchema = z.object({
   classId: z.coerce
     .number({ message: "classId should be a number" })
     .int({ message: "classId should be an integer" })
     .positive({ message: "classId should be a positive integer" }),
 });
 
-export const getJoinLinkParamSchema = deleteClassParamsSchema;
+export const getClassStudentParamSchema = deleteClassParamSchema;
 
-export const patchJoinLinkParamSchema = deleteClassParamsSchema;
+export const getJoinLinkParamSchema = deleteClassParamSchema;
 
-export const getClassroomParamSchema = deleteClassParamsSchema;
+export const patchJoinLinkParamSchema = deleteClassParamSchema;
+
+export const getClassroomParamSchema = deleteClassParamSchema;

--- a/dwengo_backend/zodSchemas/localLearningObjectSchemas.ts
+++ b/dwengo_backend/zodSchemas/localLearningObjectSchemas.ts
@@ -1,7 +1,59 @@
 import { z } from "zod";
 
+export const ContentType = {
+  TEXT_PLAIN: "TEXT_PLAIN",
+  TEXT_MARKDOWN: "TEXT_MARKDOWN",
+  IMAGE_IMAGE_BLOCK: "IMAGE_IMAGE_BLOCK",
+  IMAGE_IMAGE: "IMAGE_IMAGE",
+  AUDIO_MPEG: "AUDIO_MPEG",
+  VIDEO: "VIDEO",
+  EVAL_MULTIPLE_CHOICE: "EVAL_MULTIPLE_CHOICE",
+  EVAL_OPEN_QUESTION: "EVAL_OPEN_QUESTION",
+} as const;
+
+export const ContentTypeSchema = z.enum([
+  ContentType.TEXT_PLAIN,
+  ContentType.TEXT_MARKDOWN,
+  ContentType.IMAGE_IMAGE_BLOCK,
+  ContentType.IMAGE_IMAGE,
+  ContentType.AUDIO_MPEG,
+  ContentType.VIDEO,
+  ContentType.EVAL_MULTIPLE_CHOICE,
+  ContentType.EVAL_OPEN_QUESTION,
+]);
+
+export const LocalLearningObjectBodySchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  contentType: ContentTypeSchema,
+  keywords: z.array(z.string()).optional(),
+  targetAges: z.array(z.number()).optional(),
+  teacherExclusive: z.boolean().optional(),
+  skosConcepts: z.array(z.string()).optional(),
+  copyright: z.string().optional(),
+  licence: z.string().optional(),
+  difficulty: z.number().optional(),
+  estimatedTime: z.number().optional(),
+  available: z.boolean().optional(),
+  contentLocation: z.string().optional(),
+});
+
+// Optional inferred type
+export type LocalLearningObjectData = z.infer<
+  typeof LocalLearningObjectBodySchema
+>;
+
 export const getLocalLearningObjectParamsSchema = z.object({
   id: z.coerce.string({
     message: "LLO-id was missing or couldn't be converted to a string",
   }),
 });
+
+export const updateLocalLearningObjectBodySchema =
+  LocalLearningObjectBodySchema.partial();
+
+export const updateLocalLearningObjectParamSchema =
+  getLocalLearningObjectParamsSchema;
+
+export const deleteLocalLearningObjectParamSchema =
+  getLocalLearningObjectParamsSchema;

--- a/dwengo_backend/zodSchemas/localLearningPathNodeSchemas.ts
+++ b/dwengo_backend/zodSchemas/localLearningPathNodeSchemas.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const getLocalLearningPathNodeParamsSchema = z.object({
+  pathId: z.coerce.string({
+    message: "LLPath-id was missing or couldn't be converted to a string",
+  }),
+});
+
+export const createNodeBodySchema = z.object({
+  isExternal: z.boolean(),
+  localLearningObjectId: z.string().optional(),
+  dwengoHruid: z.string().optional(),
+  dwengoLanguage: z.string().optional(),
+  dwengoVersion: z.number().optional(),
+  start_node: z.boolean().optional(),
+});
+
+export const createNodeParamSchema = getLocalLearningPathNodeParamsSchema;
+
+export const updateNodeBodySchema = createNodeBodySchema;
+
+export const updateNodeParamSchema = z.object({
+  pathId: z.coerce.string({
+    message: "LLPath-id was missing or couldn't be converted to a string",
+  }),
+  nodeId: z.coerce.string({
+    message: "LLNode-id was missing or couldn't be converted to a string",
+  }),
+});
+
+export const deleteNodeParamSchema = updateNodeParamSchema;

--- a/dwengo_backend/zodSchemas/localLearningPathSchemas.ts
+++ b/dwengo_backend/zodSchemas/localLearningPathSchemas.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const createLocalLearningPathBodySchema = z.object({
+  title: z.string().min(1, { message: "Title is required" }), // Ensures 'title' is not empty
+  language: z.string().min(1, { message: "Language is required" }), // Ensures 'language' is not empty
+  description: z.string().optional(), // 'description' is optional
+  image: z.string().nullable().optional(), // 'image' can be a string, null, or undefined (optional)
+});
+
+export const getLocalLearningPathParamsSchema = z.object({
+  pathId: z.coerce.string({
+    message: "LLPath-id was missing or couldn't be converted to a string",
+  }),
+});
+
+export const updateLocalLearningPathParamsSchema =
+  getLocalLearningPathParamsSchema;
+
+export const deleteLocalLearningPathParamsSchema =
+  getLocalLearningPathParamsSchema;

--- a/dwengo_backend/zodSchemas/studentClassSchemas/classIdSchema.ts
+++ b/dwengo_backend/zodSchemas/studentClassSchemas/classIdSchema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const classIdParamsSchema = z.object({
+  classId: z.coerce.number().int().positive(),
+});

--- a/dwengo_backend/zodSchemas/teamSchemas.ts
+++ b/dwengo_backend/zodSchemas/teamSchemas.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+const TeamDivisionSchema = z.object({
+  teamName: z.string().min(1, { message: "Team name cannot be empty" }),
+  studentIds: z
+    .array(z.number().int().positive())
+    .nonempty({ message: "Each team must have at least one student" }),
+});
+
+const IdentifiableTeamDivisionSchema = TeamDivisionSchema.extend({
+  teamId: z.number().int().positive(),
+});
+
+export const createTeamParamSchema = z.object({
+  assignmentId: z.coerce.number().int().positive({
+    message: "assignmentId must be a positive integer",
+  }),
+  classId: z.coerce.number().int().positive({
+    message: "classId must be a positive integer",
+  }),
+});
+
+export const createTeamBodySchema = z.object({
+  teams: z.array(TeamDivisionSchema),
+});
+
+export const getTeamParamSchema = z.object({
+  assignmentId: z.coerce.number().int().positive({
+    message: "assignmentId must be a positive integer",
+  }),
+});
+
+export const updateTeamParamSchema = getTeamParamSchema;
+
+export const updateTeamBodySchema = z.object({
+  teams: z.array(IdentifiableTeamDivisionSchema),
+});
+
+export const deleteTeamParamSchema = getTeamParamSchema;

--- a/dwengo_backend/zodSchemas/userSchemas.ts
+++ b/dwengo_backend/zodSchemas/userSchemas.ts
@@ -1,8 +1,14 @@
 import { z } from "zod";
 
-export const registerUserSchema = z.object({
+export const registerUserBodySchema = z.object({
   firstName: z.string().min(1, "First name is required"),
   lastName: z.string().min(1, "Last name is required"),
   email: z.string().email("Invalid email address"),
   password: z.string().min(6, "Password must be at least 6 characters"),
+});
+
+export const loginUserBodySchema = z.object({
+  email: z.string().email({ message: "Voer een geldig e-mailadres in" }), // Zod's built-in email validation
+  // Password is already enforced to be long enough during registration
+  password: z.string(), // Add any password validation as needed
 });


### PR DESCRIPTION
De classRoutes gebruiken nu Zod Validatie om de "classId" parameter om te zetten naar een Number. 

Als dit niet lukt gooit de validateRequest functie nu een BadRequestError in plaats van een json object met error code 400 (zelfde als badrequest) en een paar velden (die nu ook in BadRequestError verwerkt zitten).

Bovendien past de validaterequest functie nu ook de data in .body of .request aan. Zodat er in de controllers niet meer moet geparsed worden met Number(...) of parseInt(...). 
Om de type-warnings op te lossen doe ik nu steeds "classId as unknow as number". 
Dit is normaalgezien slechte code stijl maar wij kunnen nu garanderen dat de zodValidatie zijn ding doet, waardoor dit geen probleem is.

Dit is de 3de keer dat ik aan een branch genaamd zod-validatie begin, omdat ik alle vorige keren veel te lang wachtte met een PR te maken, waarna de routes aangepast werden en mijn code niet meer bruikbaar was.
Vandaar dat ik deze keer een PR per route-set ga aanmaken.

Alle testen slagen (behalve die van die questions, die worden in een andere PR al gefixed).
