### PR TITLE
on the fly

### DIFF
--- a/dwengo_backend/config/cors.ts
+++ b/dwengo_backend/config/cors.ts
@@ -15,14 +15,22 @@ const corsMiddleware = (
   if (origin && allowedOrigins.includes(origin)) {
     res.setHeader("Access-Control-Allow-Origin", origin);
   }
+
   res.setHeader(
     "Access-Control-Allow-Methods",
     "GET, POST, PUT, DELETE, OPTIONS, PATCH",
   );
+
   res.setHeader(
     "Access-Control-Allow-Headers",
     "X-Requested-With, Content-Type, Authorization",
   );
+
+  if (req.method === "OPTIONS") {
+    res.sendStatus(204);
+    return;
+  }
+
   next();
 };
 

--- a/dwengo_backend/controllers/progressController.ts
+++ b/dwengo_backend/controllers/progressController.ts
@@ -266,3 +266,37 @@ export const getAssignmentAverageProgress = asyncHandler(
     res.status(200).json({ averageProgress });
   },
 );
+
+
+
+/**
+ * Creates or updates progress for a student's learning object.
+ * If progress doesn't exist, creates it. If it exists, updates it.
+ */
+export const upsertProgress = asyncHandler(
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const studentId: number = getUserFromAuthRequest(req).id;
+    const { learningObjectId } = req.params;
+
+    try {
+      const existingProgress = await progressService.getStudentProgress(
+        studentId,
+        learningObjectId
+      );
+      const progress = await progressService.updateProgressToDone(existingProgress.id);
+
+      res.status(200).json({
+        message: "Progress successfully updated",
+        progress: progress,
+      });
+
+    } catch {
+      const progress = await progressService.createProgress(studentId, learningObjectId);
+
+      res.status(201).json({
+        message: "Progress successfully created",
+        progress: progress,
+      });
+    }
+  }
+);

--- a/dwengo_backend/package.json
+++ b/dwengo_backend/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "main": "server.ts",
   "scripts": {
-    "dev": "nodemon --watch '**/*.ts' --exec ts-node index.ts",
-    "start": "cross-env NODE_ENV=production ts-node index.ts",
+    "dev": "nodemon --watch '**/*.ts' --exec ts-node server.ts",
+    "start": "cross-env NODE_ENV=production ts-node server.ts",
 
     "test:unit": "vitest run -c ./vitest.config.unit.ts",
     "test:unit:ui": "vitest -c ./vitest.config.unit.ts --ui",

--- a/dwengo_backend/routes/progress/studentProgressRoutes.ts
+++ b/dwengo_backend/routes/progress/studentProgressRoutes.ts
@@ -6,6 +6,7 @@ import {
   getStudentProgress,
   getTeamProgressStudent,
   updateProgress,
+  upsertProgress,
 } from "../../controllers/progressController";
 import { protectStudent } from "../../middleware/authMiddleware/studentAuthMiddleware";
 import { validateRequest } from "../../middleware/validateRequest";
@@ -123,6 +124,23 @@ router.get(
     paramsSchema: learningPathIdParamSchema,
   }),
   getStudentLearningPathProgress,
+);
+
+/**
+ * @route   PUT /progress/student/learningObject/:learningObjectId
+ * @desc    Create or update progress for a student's learning object (upsert).
+ *          If progress doesn't exist, it will be created.
+ *          If it exists, it will be updated.
+ * @param   learningObjectId: string
+ * @access  Student
+ */
+router.put(
+  "/learningObject/:learningObjectId",
+  validateRequest({
+    customErrorMessage: "invalid learningObjectId request parameter",
+    paramsSchema: learningObjectIdParamSchema,
+  }),
+  upsertProgress,
 );
 
 export default router;

--- a/dwengo_backend/services/combinedLearningPathService.ts
+++ b/dwengo_backend/services/combinedLearningPathService.ts
@@ -12,6 +12,7 @@ interface CombinedLearningPathFilters {
   title?: string;
   description?: string;
   all?: string;
+  includeProgress?: string;
 }
 
 /**

--- a/dwengo_backend/services/learningPathService.ts
+++ b/dwengo_backend/services/learningPathService.ts
@@ -6,7 +6,7 @@ import {
 import { NotFoundError } from "../errors/errors";
 
 export interface LearningPathDto {
-  _id: string; // Dwengo gebruikt _id of in onze DB is het id
+  _id: string;
   hruid: string;
   language: string;
   title: string;
@@ -14,7 +14,7 @@ export interface LearningPathDto {
   image?: string;
   num_nodes?: number;
   num_nodes_left: number;
-  // properderr dan die any
+
   nodes: Array<{
     nodeId: string;
     isExternal: boolean;
@@ -23,11 +23,14 @@ export interface LearningPathDto {
     done: boolean;
   }>;
 
+  /** NIEUW voor deprogress per leerpaden */
+  totalNodes?: number; // aantal nodes in dit leerpad
+  completedNodes?: number; // hoeveel daarvan done = true
+  progressPercent?: number; // afgerond percentage 0-100
+
   createdAt?: string;
   updatedAt?: string;
 
-  // ===== BELANGRIJK =====
-  // Zodat we Dwengo vs. lokaal kunnen onderscheiden in 1 type:
   isExternal: boolean;
 }
 

--- a/dwengo_backend/services/learningPathService.ts
+++ b/dwengo_backend/services/learningPathService.ts
@@ -23,8 +23,7 @@ export interface LearningPathDto {
     done: boolean;
   }>;
 
-  /** NIEUW voor deprogress per leerpaden */
-  totalNodes?: number; // aantal nodes in dit leerpad
+  /** NIEUW voor de progress per leerpaden */
   completedNodes?: number; // hoeveel daarvan done = true
   progressPercent?: number; // afgerond percentage 0-100
 
@@ -36,6 +35,10 @@ export interface LearningPathDto {
 
 // Dwengo -> Local mapping
 function mapDwengoPathToLocal(dwengoPath: any): LearningPathDto {
+  const nodes = dwengoPath.nodes ?? [];
+  const completedNodes = nodes.filter((node: any) => node.done).length;
+  const progressPercent = Math.round((completedNodes / (dwengoPath.num_nodes ?? 0)) * 100) || 0;
+
   return {
     _id: dwengoPath._id ?? "",
     hruid: dwengoPath.hruid ?? "",
@@ -45,10 +48,11 @@ function mapDwengoPathToLocal(dwengoPath: any): LearningPathDto {
     image: dwengoPath.image ?? "",
     num_nodes: dwengoPath.num_nodes ?? 0,
     num_nodes_left: dwengoPath.num_nodes_left ?? 0,
-    nodes: dwengoPath.nodes ?? [],
+    nodes: nodes,
+    completedNodes,
+    progressPercent,
     createdAt: dwengoPath.created_at ?? "",
     updatedAt: dwengoPath.updatedAt ?? "",
-    // Nieuw: Dwengo => altijd true
     isExternal: true,
   };
 }

--- a/dwengo_backend/services/localLearningPathService.ts
+++ b/dwengo_backend/services/localLearningPathService.ts
@@ -178,63 +178,70 @@ export class LocalLearningPathService {
     includeProgress: boolean = false,
     studentId?: number,
   ): Promise<LearningPathDto> {
-    // 1) Probeer op id
-    const byId = await handlePrismaQuery(() =>
-      prisma.learningPath.findUnique({ where: { id: idOrHruid } }),
-    );
-
-    // 2) Probeer op hruid als niet op id gevonden
+    /* 1.  Zoek leerpad-record (op id of hruid) */
     const lp =
-      byId ??
+      (await handlePrismaQuery(() =>
+        prisma.learningPath.findUnique({ where: { id: idOrHruid } }),
+      )) ??
       (await handlePrismaQuery(() =>
         prisma.learningPath.findUnique({ where: { hruid: idOrHruid } }),
       ));
 
     if (!lp) throw new NotFoundError("Learning path not found.");
 
-    // Basis DTO zonder nodes
+    /* 2.  Basis-DTO (zonder nodes) */
     const baseDto = mapLocalPathToDto(lp);
 
-    // Als geen progressie nodig is of geen studentId, geef alleen basis terug
+    /* 3.  Als progress niet gevraagd of geen studentId → klaar */
     if (!includeProgress || studentId === undefined) {
       return baseDto;
     }
 
-    // Haal alle nodes van dit leerpad
+    /* 4.  Nodes ophalen */
     const nodes = await prisma.learningPathNode.findMany({
       where: { learningPathId: lp.id },
     });
 
-    // Voor elke node: bepaal done-status
+    /* 5.  Voor elke node bepalen of de student klaar is */
     const nodesWithProgress = await Promise.all(
       nodes.map(async (node) => {
         let done = false;
-        const localObjId = node.localLearningObjectId;
-        if (localObjId) {
-          // Zoek studentProgress met relation filter op LearningObjectProgress
+
+        if (node.localLearningObjectId) {
           const sp = await prisma.studentProgress.findFirst({
             where: {
               studentId,
               progress: {
-                is: { learningObjectId: localObjId },
+                is: { learningObjectId: node.localLearningObjectId },
               },
             },
           });
           done = sp !== null;
         }
+
         return {
           nodeId: node.nodeId,
           isExternal: node.isExternal,
           localLearningObjectId: node.localLearningObjectId ?? undefined,
           dwengoHruid: node.dwengoHruid ?? undefined,
-          done: done,
+          done,
         };
       }),
     );
 
+    /* 6.  Leerpad-aggregatie */
+    const totalNodes = nodesWithProgress.length;
+    const completedNodes = nodesWithProgress.filter((n) => n.done).length;
+    const progressPercent =
+      totalNodes === 0 ? 0 : Math.round((completedNodes / totalNodes) * 100);
+
+    /* 7.  Eind-DTO met voortgang */
     return {
       ...baseDto,
       nodes: nodesWithProgress,
+      totalNodes,
+      completedNodes,
+      progressPercent,
     };
   }
 }

--- a/dwengo_backend/services/localLearningPathService.ts
+++ b/dwengo_backend/services/localLearningPathService.ts
@@ -239,7 +239,6 @@ export class LocalLearningPathService {
     return {
       ...baseDto,
       nodes: nodesWithProgress,
-      totalNodes,
       completedNodes,
       progressPercent,
     };

--- a/dwengo_backend/services/progressService.ts
+++ b/dwengo_backend/services/progressService.ts
@@ -31,7 +31,7 @@ class ProgressService {
       const progress = await transactionPrisma.learningObjectProgress.create({
         data: {
           learningObjectId,
-          done: false,
+          done: true,
         },
       });
 

--- a/frontend/src/components/student/NavStudent.tsx
+++ b/frontend/src/components/student/NavStudent.tsx
@@ -32,6 +32,11 @@ const Navstudent: React.FC = () => {
       to: '/student/klassen',
       label: t('nav.classes'),
     },
+    {
+      to: '/student/learning-paths',
+      label: t('nav.learning_paths'),
+    },
+
   ];
 
   return (
@@ -53,9 +58,8 @@ const Navstudent: React.FC = () => {
               </div>
             ) : (
               <div
-                className={`flex flex-row justify-end w-full ${
-                  styles.navLinks
-                } ${menuOpen ? styles.open : ''}`}
+                className={`flex flex-row justify-end w-full ${styles.navLinks
+                  } ${menuOpen ? styles.open : ''}`}
               >
                 <NavButton to="/student/inloggen" label={t('nav.login')} />
                 <NavButton

--- a/frontend/src/components/teacher/ClassesOverviewTeacher.tsx
+++ b/frontend/src/components/teacher/ClassesOverviewTeacher.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import PrimaryButton from '../shared/PrimaryButton';
 import React from 'react';
-import { ClassItem } from '../../types/type';
+import { ClassItem } from '@/types/type';
 import { useTranslation } from 'react-i18next';
 import { fetchClasses } from '@/util/teacher/class';
 
@@ -21,7 +21,7 @@ export default function ClassesOverviewTeacher() {
 
   return (
     <>
-      <div className="w-full flex flex-row gap-5 flex-wrap">
+      <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
         {isLoading && <p>{t('loading.loading')}</p>}
         {isError && (
           <p className="c-r">{error?.info?.message || t('classes.error')}</p>
@@ -32,7 +32,7 @@ export default function ClassesOverviewTeacher() {
             {classes.map((classItem) => (
               <div
                 key={classItem.id}
-                className="flex items-center flex-row w-[20rem] p-4 justify-between bg-gray-100 rounded-lg shrink-0"
+                className="flex flex-col p-4 justify-between bg-white shadow-md rounded-lg mb-4 max-w-[20rem] w-full"
               >
                 <div className="flex flex-col">
                   <div className="flex flex-row w-full justify-between mb-1">

--- a/frontend/src/components/teacher/RootLayoutTeacher.tsx
+++ b/frontend/src/components/teacher/RootLayoutTeacher.tsx
@@ -1,17 +1,22 @@
-import { Outlet } from "react-router-dom";
-import Nav from "./NavTeacher";
-import React from "react";
+import { Outlet } from 'react-router-dom';
+import Nav from './NavTeacher';
+import React from 'react';
 
 function RootLayoutTeacher() {
   return (
-    <>
-      <Nav />
+    <div className="min-h-screen flex flex-col bg-gray-50 text-gray-900">
+      {/* Navigation */}
+      <header className="shadow bg-white">
+        <Nav />
+      </header>
 
-      <main>
-        {/* {navigation.state === 'loading' && <p>Loading...</p>} */}
-        <Outlet />
+      {/* Main content wrapper */}
+      <main className="flex-1 px-4 py-8 sm:px-6 lg:px-8">
+        <div className="bg-white shadow rounded-xl p-6 max-w-screen-xl mx-auto w-full">
+          <Outlet />
+        </div>
       </main>
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/components/teacher/assignment/AddAssignmentForm.tsx
+++ b/frontend/src/components/teacher/assignment/AddAssignmentForm.tsx
@@ -13,7 +13,7 @@ import {
   StudentItem,
   Team,
 } from '../../../types/type';
-import { fetchLearningPaths } from '@/util/teacher/learningPath';
+import { fetchLearningPaths } from '@/util/shared/learningPath';
 import { postAssignment, updateAssignment } from '@/util/teacher/assignment';
 import { useTranslation } from 'react-i18next';
 
@@ -333,7 +333,7 @@ const AddAssignmentForm = ({
       );
       setSubmitError(
         error.message ||
-          `Failed to ${isEditing ? 'update' : 'create'} assignment`,
+        `Failed to ${isEditing ? 'update' : 'create'} assignment`,
       );
       setIsSubmitting(false);
     }

--- a/frontend/src/pages/learningPath/learningPath.tsx
+++ b/frontend/src/pages/learningPath/learningPath.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useMemo, useEffect, use } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { LearningPath } from '../../types/type';
 import { useParams } from 'react-router-dom';
 import { LearningObject } from '@prisma/client';
-import { fetchLearningObjectsByLearningPath, fetchLearningPath } from '@/util/teacher/learningPath';
+import { fetchLearningObjectsByLearningPath, fetchLearningPath } from '@/util/shared/learningPath';
+import { upsertLearningObjectProgress } from '@/util/student/progress';
 
 /**
  * LearningPaths component displays all available learning paths.
@@ -20,33 +21,27 @@ import { fetchLearningObjectsByLearningPath, fetchLearningPath } from '@/util/te
 const LearningPath: React.FC = () => {
     const [learningPath, setLearningPath] = useState<LearningPath | null>(null);
     const [selectedLearningObject, setSelectedLearningObject] = useState<LearningObject | null>(null);
-
     const { pathId } = useParams<{ pathId: string }>();
-
-    const {
-        data: learningPathData,
-        isLoading,
-        isError,
-        error,
-    } = useQuery<LearningPath>({
-        queryKey: ['learningPaths', pathId],
-        queryFn: () => fetchLearningPath(pathId!, true),
-        staleTime: 5 * 60 * 1000, // Consider data fresh for 5 minutes
-        gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes
-    });
-
-    console.log('LearningPathData', learningPathData);
-
-    const {
-        data: learningObjectsData,
-        isLoading: isLoadingLearningObjects,
-        isError: isErrorLearningObjects,
-        error: errorLearningObjects,
-    } = useQuery<LearningObject[]>({
-        queryKey: ['learningObjects', pathId],
-        queryFn: () => fetchLearningObjectsByLearningPath(pathId!),
-        staleTime: 5 * 60 * 1000, // Consider data fresh for 5 minutes
-        gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes
+    const [progress, setProgress] = useState<number>(0);
+    const [isStudent, setIsStudent] = useState<boolean>(localStorage.getItem('role') === 'student');
+    const [
+        { data: learningPathData, isLoading, isError, error },
+        { data: learningObjectsData, isLoading: isLoadingLearningObjects, isError: isErrorLearningObjects, error: errorLearningObjects },
+    ] = useQueries({
+        queries: [
+            {
+                queryKey: ['learningPaths', pathId],
+                queryFn: () => fetchLearningPath(pathId!, true),
+                staleTime: 5 * 60 * 1000,
+                gcTime: 30 * 60 * 1000,
+            },
+            {
+                queryKey: ['learningObjects', pathId],
+                queryFn: () => fetchLearningObjectsByLearningPath(pathId!),
+                staleTime: 5 * 60 * 1000,
+                gcTime: 30 * 60 * 1000,
+            },
+        ]
     });
 
     const nextObject = useMemo(() => {
@@ -55,12 +50,38 @@ const LearningPath: React.FC = () => {
         return learningObjectsData[idx + 1] || null;
     }, [selectedLearningObject, learningObjectsData]);
 
-
     useEffect(() => {
         if (learningPathData) {
             setLearningPath(learningPathData);
         }
     }, [learningPathData]);
+
+    useEffect(() => {
+        if (isStudent && learningPath) {
+            calculateProgress();
+        }
+    }, [learningPath]);
+
+    const calculateProgress = () => {
+        if (!learningPath) return 0;
+        const totalNodes = learningPath.nodes.length;
+        const completedNodes = learningPath.nodes.filter(node => node.done).length;
+
+        setProgress((completedNodes / totalNodes) * 100);
+    }
+
+    // Handle click on learning object
+    const handleClickLearningObject = async (learningObject: LearningObject) => {
+        if (selectedLearningObject && isStudent) {
+            await upsertLearningObjectProgress(selectedLearningObject!.id, true);
+            learningPath!.nodes.find(obj => obj.localLearningObjectId === selectedLearningObject!.id)!.done = true;
+            calculateProgress();
+        }
+        if (!learningObject) return;
+        setSelectedLearningObject(learningObject);
+    };
+
+    console.log('progress', progress);
 
     return (
         <div className="flex min-h-[calc(100vh-80px)]">
@@ -75,6 +96,17 @@ const LearningPath: React.FC = () => {
                         <>
                             <div className="flex gap-2.5 -m-2.5 p-2.5 border-b border-gray-200">
                                 <h2 className="text-xl font-bold">{learningPath?.title}</h2>
+                                {isStudent && (
+                                    <div className="flex items-center gap-2 ml-auto">
+                                        <div className="w-32 h-2 bg-gray-200 rounded-full overflow-hidden">
+                                            <div
+                                                className="h-full bg-blue-600 rounded-full transition-all duration-300"
+                                                style={{ width: `${progress}%` }}
+                                            />
+                                        </div>
+                                        <span className="text-sm text-gray-600">{Math.round(progress)}%</span>
+                                    </div>
+                                )}
                             </div>
                             <div className="flex flex-col overflow-y-auto">
                                 {learningObjectsData?.map((learningObject) => (
@@ -84,9 +116,35 @@ const LearningPath: React.FC = () => {
                                             : ''
                                             }`}
                                         key={learningObject.id}
-                                        onClick={() => setSelectedLearningObject(learningObject)}
+                                        onClick={() => handleClickLearningObject(learningObject)}
                                     >
-                                        {learningObject.title}
+                                        <div className="flex items-center justify-between">
+                                            <span>{learningObject.title}</span>
+                                            <svg
+                                                className={`w-5 h-5 ${learningObject.done ? 'text-green-500' : 'text-gray-300'}`}
+                                                fill="none"
+                                                stroke="currentColor"
+                                                viewBox="0 0 24 24"
+                                            >
+                                                {learningPathData?.nodes.find(node => node.localLearningObjectId === learningObject.id && node.done) ? (
+                                                    <path
+                                                        strokeLinecap="round"
+                                                        strokeLinejoin="round"
+                                                        strokeWidth={2}
+                                                        d="M5 13l4 4L19 7"
+                                                        color='green'
+                                                    />
+                                                ) : (
+                                                    <circle
+                                                        cx="12"
+                                                        cy="12"
+                                                        r="8"
+                                                        strokeWidth={2}
+                                                        color='gray'
+                                                    />
+                                                )}
+                                            </svg>
+                                        </div>
                                     </button>
                                 ))}
                             </div>
@@ -102,6 +160,7 @@ const LearningPath: React.FC = () => {
                         <>
                             <h3 className="w-fit mx-auto font-bold text-2xl">{learningPath?.title}</h3>
                             <p className="py-2 pb-6 w-fit mx-auto">{learningPath?.description}</p>
+
                         </>
                     ) : (
                         <div className="w-full max-w-3xl">
@@ -114,15 +173,22 @@ const LearningPath: React.FC = () => {
                     )}
                 </div>
                 <div className="fixed bottom-0 right-0 flex p-4 justify-end border-t border-gray-200 bg-white w-[calc(100%-416px)] z-10">
-                    <button
-                        className="px-4 py-2 text-base font-normal rounded bg-blue-600 text-white border-none cursor-pointer transition-opacity duration-200 disabled:opacity-50"
-                        onClick={() => nextObject && setSelectedLearningObject(nextObject)}
-                        disabled={!nextObject}
-                    >
-                        {nextObject
-                            ? `Up Next: ${nextObject.title}`
-                            : 'End of Path'}
-                    </button>
+                    {isStudent && (
+                        <button
+                            className="px-4 py-2 text-base font-normal rounded bg-blue-600 text-white border-none cursor-pointer transition-opacity duration-200 disabled:opacity-50"
+                            onClick={() => {
+                                handleClickLearningObject(nextObject)
+                                if (nextObject == null) {
+                                    //TODO
+                                }
+                            }}
+                            disabled={progress === 100}
+                        >
+                            {nextObject
+                                ? `Up Next: ${nextObject.title}`
+                                : 'Complete Learning Path'}
+                        </button>
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/pages/learningPath/learningPaths.tsx
+++ b/frontend/src/pages/learningPath/learningPaths.tsx
@@ -5,7 +5,7 @@ import { LearningPathFilter } from '../../components/learningPath/learningPathFi
 import { Filter, FilterType } from '../../components/ui/filters';
 import { Link } from 'react-router-dom';
 import { filterLearningPaths } from '@/util/filter';
-import { fetchLearningPaths } from '@/util/teacher/learningPath';
+import { fetchLearningPaths } from '@/util/shared/learningPath';
 
 /**
  * Generates a background color based on the given ID.

--- a/frontend/src/pages/student/LoginStudent.tsx
+++ b/frontend/src/pages/student/LoginStudent.tsx
@@ -50,8 +50,9 @@ const LoginStudent: React.FC = () => {
       localStorage.setItem('firstName', data.firstName);
       localStorage.setItem('lastName', data.lastName);
       localStorage.setItem('expiration', expires.toISOString());
+      localStorage.setItem('role', 'student')
 
-      navigate('/student/dashboard');
+      navigate('/student');
     },
   });
 

--- a/frontend/src/pages/teacher/Assignment.tsx
+++ b/frontend/src/pages/teacher/Assignment.tsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { LearningPath } from '../../types/type';
 import { AssignmentPayload } from '../../types/type';
 import { deleteAssignment, fetchAssignment } from '@/util/teacher/assignment';
-import { fetchLearningPath } from '@/util/teacher/learningPath';
+import { fetchLearningPath } from '@/util/shared/learningPath';
 
 /**
  * Assignment component for teachers to view and manage individual assignments.

--- a/frontend/src/pages/teacher/TeacherIndex.tsx
+++ b/frontend/src/pages/teacher/TeacherIndex.tsx
@@ -9,7 +9,7 @@ export default function TeacherIndex() {
   const { t } = useTranslation();
   return (
     <>
-      <div className="px-10 bg-gray-300">
+      <div className="px-10 bg-gray-300 rounded-xl">
         <div className="text-6xl pt-12 font-bold">{t('home')}</div>
 
         <h2 className="mt-8 text-2xl font-bold">{t('assignments.label')}</h2>

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -41,7 +41,8 @@ const HomePage: React.FC = () => {
       <div className="absolute top-4 right-4">
         <LanguageChooser />
       </div>
-      <div className="flex flex-col justify-center items-center h-screen">
+      # TODO: zoek een image zodat de achtergrond niet saai wit is
+      <div className="flex flex-col justify-center items-center h-screen bg-[url('/path-to-your-image.jpg')] bg-cover bg-center">
         <div className="-translate-y-20">
           <h2 className="justify-center flex flex-row font-bold text-5xl mb-8">
             {t('role.choose')}

--- a/frontend/src/util/shared/auth.ts
+++ b/frontend/src/util/shared/auth.ts
@@ -1,0 +1,17 @@
+import jwt_decode from 'jwt-decode';
+
+interface DecodedToken {
+  role: string;
+}
+
+export const getRole = (): string | null => {
+  const token = localStorage.getItem('token');
+  if (!token) return null;
+  
+  try {
+    const decoded = jwt_decode<DecodedToken>(token);
+    return decoded.role;
+  } catch {
+    return null;
+  }
+};

--- a/frontend/src/util/shared/config.ts
+++ b/frontend/src/util/shared/config.ts
@@ -12,7 +12,7 @@ export const queryClient = new QueryClient({
 });
 
 export interface RequestConfig {
-  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT';
   endpoint: string;
   body?: any;
   getToken: () => string | null;

--- a/frontend/src/util/shared/learningPath.ts
+++ b/frontend/src/util/shared/learningPath.ts
@@ -1,6 +1,23 @@
 import { LearningPath } from '@/types/type';
-import { getAuthToken } from './authTeacher';
-import { apiRequest } from '../shared/config';
+import { getTokenDuration } from '../teacher/authTeacher';
+import { apiRequest } from './config';
+
+export function getAuthToken(): string | null {
+  const token = localStorage.getItem('token');
+
+  if (!token) {
+    return null;
+  }
+
+  const tokenDuration = getTokenDuration();
+
+  if (tokenDuration < 0) {
+    return 'EXPIRED';
+  }
+
+  return token;
+}
+
 
 /**
  * Fetches all learning paths for the authenticated teacher
@@ -10,7 +27,7 @@ import { apiRequest } from '../shared/config';
 export async function fetchLearningPaths(): Promise<LearningPath[]> {
   const response = (await apiRequest({
     method: 'GET',
-    endpoint: '/pathByTeacher/all',
+    endpoint: '/learningpath?all',
     getToken: getAuthToken,
   })) as { learningPaths: LearningPath[] };
 
@@ -38,7 +55,7 @@ export async function fetchLearningPath(
 
   return (await apiRequest({
     method: 'GET',
-    endpoint: `/pathByTeacher/all/${learningPathId}?isExternal=${isExternal}`,
+    endpoint: `/learningpath/${learningPathId}?includeProgress=true`,
     getToken: getAuthToken,
   })) as { learningPath: LearningPath };
 }

--- a/frontend/src/util/student/progress.ts
+++ b/frontend/src/util/student/progress.ts
@@ -1,0 +1,75 @@
+import { APIError, AssignmentItem } from '@/types/api.types';
+import { getAuthToken } from './authStudent';
+import { apiRequest, BACKEND } from '../shared/config';
+
+
+// Create progress for a learning object
+export async function createLearningObjectProgress(learningObjectId: string) {
+    return await apiRequest({
+        method: 'POST',
+        endpoint: `/progress/student/learningObject/${learningObjectId}`,
+        getToken: getAuthToken,
+    });
+}
+
+// Get progress for a learning object
+export async function getLearningObjectProgress(learningObjectId: string) {
+    return await apiRequest({
+        method: 'GET',
+        endpoint: `/progress/student/learningObject/${learningObjectId}`,
+        getToken: getAuthToken,
+    });
+}
+
+// Update progress for a learning object
+export async function updateLearningObjectProgress(learningObjectId: string, done: boolean) {
+    return await apiRequest({
+        method: 'PATCH',
+        endpoint: `/progress/student/learningObject/${learningObjectId}`,
+        body: {
+            done
+        },
+        getToken: getAuthToken,
+    });
+}
+
+// Get team progress
+export async function getTeamProgress(teamId: number) {
+    return await apiRequest({
+        method: 'GET',
+        endpoint: `/progress/student/team/${teamId}`,
+        getToken: getAuthToken,
+    });
+}
+
+// Get assignment progress
+export async function getAssignmentProgress(assignmentId: number) {
+    return await apiRequest({
+        method: 'GET',
+        endpoint: `/progress/student/assignment/${assignmentId}`,
+        getToken: getAuthToken,
+    });
+}
+
+// Get learning path progress
+export async function getLearningPathProgress(learningPathId: string) {
+    return await apiRequest({
+        method: 'GET',
+        endpoint: `/progress/student/learningPath/${learningPathId}`,
+        getToken: getAuthToken,
+    });
+}
+
+// ...existing code...
+
+// Upsert progress for a learning object (create or update)
+export async function upsertLearningObjectProgress(learningObjectId: string, done: boolean) {
+    return await apiRequest({
+        method: 'PUT',
+        endpoint: `/progress/student/learningObject/${learningObjectId}`,
+        body: {
+            done
+        },
+        getToken: getAuthToken,
+    });
+}


### PR DESCRIPTION
**Wijzigingen**
1. `services/learningPathService.ts`
   * DTO nu +3 velden: `totalNodes`, `completedNodes`, `progressPercent`.
   * Dwengo-mapping berekent deze veldenn

2. `services/localLearningPathService.ts`
   * `mapLocalPathToDto` placeholders voor de 3 velden.
   * `getLearningPathAsDtoByIdOrHruid`::
     * bepaalt `done` per node
     * voegt aggregatievelden teo
DUS: API stuurt nu naast `nodes[].done` ook pad-niveau voortgang (teller, nooemer, %).