### PR TITLE
Progress stap 2 view

### DIFF
--- a/dwengo_backend/controllers/student/studentAssignmentController.ts
+++ b/dwengo_backend/controllers/student/studentAssignmentController.ts
@@ -4,6 +4,7 @@ import {
   getAssignmentsForStudentInClass,
   isStudentInClass,
 } from "../../services/studentAssignmentService";
+import ProgressService from "../../services/progressService";
 import { Assignment } from "@prisma/client";
 import { AuthenticatedRequest } from "../../interfaces/extendedTypeInterfaces";
 import { getUserFromAuthRequest } from "../../helpers/getUserFromAuthRequest";
@@ -42,7 +43,19 @@ export const getStudentAssignments = asyncHandler(
       order,
       limit,
     );
-    res.status(200).json(assignments);
+    console.log(assignments);
+    const assignmentsWithProgress = await Promise.all(
+      assignments.map(async (assignment) => {
+        console.log("assignment", assignment);
+        const progress = await ProgressService.getAssignmentProgressForStudent(assignment.id, studentId);
+        return {
+          ...assignment,
+          progress
+        };
+      })
+    );
+    res.status(200).json(assignmentsWithProgress);
+
   },
 );
 

--- a/dwengo_backend/services/combinedLearningPathService.ts
+++ b/dwengo_backend/services/combinedLearningPathService.ts
@@ -12,6 +12,7 @@ interface CombinedLearningPathFilters {
   title?: string;
   description?: string;
   all?: string;
+  includeProgress?: string;
 }
 
 /**

--- a/dwengo_backend/services/learningPathService.ts
+++ b/dwengo_backend/services/learningPathService.ts
@@ -6,7 +6,7 @@ import {
 import { NotFoundError } from "../errors/errors";
 
 export interface LearningPathDto {
-  _id: string; // Dwengo gebruikt _id of in onze DB is het id
+  _id: string;
   hruid: string;
   language: string;
   title: string;
@@ -14,7 +14,7 @@ export interface LearningPathDto {
   image?: string;
   num_nodes?: number;
   num_nodes_left: number;
-  // properderr dan die any
+
   nodes: Array<{
     nodeId: string;
     isExternal: boolean;
@@ -23,11 +23,14 @@ export interface LearningPathDto {
     done: boolean;
   }>;
 
+  /** NIEUW voor deprogress per leerpaden */
+  totalNodes?: number; // aantal nodes in dit leerpad
+  completedNodes?: number; // hoeveel daarvan done = true
+  progressPercent?: number; // afgerond percentage 0-100
+
   createdAt?: string;
   updatedAt?: string;
 
-  // ===== BELANGRIJK =====
-  // Zodat we Dwengo vs. lokaal kunnen onderscheiden in 1 type:
   isExternal: boolean;
 }
 

--- a/dwengo_backend/services/learningPathService.ts
+++ b/dwengo_backend/services/learningPathService.ts
@@ -23,8 +23,7 @@ export interface LearningPathDto {
     done: boolean;
   }>;
 
-  /** NIEUW voor deprogress per leerpaden */
-  totalNodes?: number; // aantal nodes in dit leerpad
+  /** NIEUW voor de progress per leerpaden */
   completedNodes?: number; // hoeveel daarvan done = true
   progressPercent?: number; // afgerond percentage 0-100
 
@@ -36,6 +35,10 @@ export interface LearningPathDto {
 
 // Dwengo -> Local mapping
 function mapDwengoPathToLocal(dwengoPath: any): LearningPathDto {
+  const nodes = dwengoPath.nodes ?? [];
+  const completedNodes = nodes.filter((node: any) => node.done).length;
+  const progressPercent = Math.round((completedNodes / (dwengoPath.num_nodes ?? 0)) * 100) || 0;
+
   return {
     _id: dwengoPath._id ?? "",
     hruid: dwengoPath.hruid ?? "",
@@ -45,10 +48,11 @@ function mapDwengoPathToLocal(dwengoPath: any): LearningPathDto {
     image: dwengoPath.image ?? "",
     num_nodes: dwengoPath.num_nodes ?? 0,
     num_nodes_left: dwengoPath.num_nodes_left ?? 0,
-    nodes: dwengoPath.nodes ?? [],
+    nodes: nodes,
+    completedNodes,
+    progressPercent,
     createdAt: dwengoPath.created_at ?? "",
     updatedAt: dwengoPath.updatedAt ?? "",
-    // Nieuw: Dwengo => altijd true
     isExternal: true,
   };
 }

--- a/dwengo_backend/services/localLearningPathService.ts
+++ b/dwengo_backend/services/localLearningPathService.ts
@@ -178,63 +178,70 @@ export class LocalLearningPathService {
     includeProgress: boolean = false,
     studentId?: number,
   ): Promise<LearningPathDto> {
-    // 1) Probeer op id
-    const byId = await handlePrismaQuery(() =>
-      prisma.learningPath.findUnique({ where: { id: idOrHruid } }),
-    );
-
-    // 2) Probeer op hruid als niet op id gevonden
+    /* 1.  Zoek leerpad-record (op id of hruid) */
     const lp =
-      byId ??
+      (await handlePrismaQuery(() =>
+        prisma.learningPath.findUnique({ where: { id: idOrHruid } }),
+      )) ??
       (await handlePrismaQuery(() =>
         prisma.learningPath.findUnique({ where: { hruid: idOrHruid } }),
       ));
 
     if (!lp) throw new NotFoundError("Learning path not found.");
 
-    // Basis DTO zonder nodes
+    /* 2.  Basis-DTO (zonder nodes) */
     const baseDto = mapLocalPathToDto(lp);
 
-    // Als geen progressie nodig is of geen studentId, geef alleen basis terug
+    /* 3.  Als progress niet gevraagd of geen studentId → klaar */
     if (!includeProgress || studentId === undefined) {
       return baseDto;
     }
 
-    // Haal alle nodes van dit leerpad
+    /* 4.  Nodes ophalen */
     const nodes = await prisma.learningPathNode.findMany({
       where: { learningPathId: lp.id },
     });
 
-    // Voor elke node: bepaal done-status
+    /* 5.  Voor elke node bepalen of de student klaar is */
     const nodesWithProgress = await Promise.all(
       nodes.map(async (node) => {
         let done = false;
-        const localObjId = node.localLearningObjectId;
-        if (localObjId) {
-          // Zoek studentProgress met relation filter op LearningObjectProgress
+
+        if (node.localLearningObjectId) {
           const sp = await prisma.studentProgress.findFirst({
             where: {
               studentId,
               progress: {
-                is: { learningObjectId: localObjId },
+                is: { learningObjectId: node.localLearningObjectId },
               },
             },
           });
           done = sp !== null;
         }
+
         return {
           nodeId: node.nodeId,
           isExternal: node.isExternal,
           localLearningObjectId: node.localLearningObjectId ?? undefined,
           dwengoHruid: node.dwengoHruid ?? undefined,
-          done: done,
+          done,
         };
       }),
     );
 
+    /* 6.  Leerpad-aggregatie */
+    const totalNodes = nodesWithProgress.length;
+    const completedNodes = nodesWithProgress.filter((n) => n.done).length;
+    const progressPercent =
+      totalNodes === 0 ? 0 : Math.round((completedNodes / totalNodes) * 100);
+
+    /* 7.  Eind-DTO met voortgang */
     return {
       ...baseDto,
       nodes: nodesWithProgress,
+      totalNodes,
+      completedNodes,
+      progressPercent,
     };
   }
 }

--- a/dwengo_backend/services/localLearningPathService.ts
+++ b/dwengo_backend/services/localLearningPathService.ts
@@ -239,7 +239,6 @@ export class LocalLearningPathService {
     return {
       ...baseDto,
       nodes: nodesWithProgress,
-      totalNodes,
       completedNodes,
       progressPercent,
     };

--- a/dwengo_backend/services/progressService.ts
+++ b/dwengo_backend/services/progressService.ts
@@ -174,6 +174,28 @@ class ProgressService {
       }),
     );
   }
+
+  /**
+   * Get the progress percentage for a student on a specific assignment.
+   * Returns 0 for external assignments.
+   */
+  async getAssignmentProgressForStudent(
+    assignmentId: number,
+    studentId: number,
+  ): Promise<number> {
+    console.log("getAssignmentProgressForStudent", studentId, assignmentId);
+    const assignment = await this.getAssignment(assignmentId);
+
+    if (assignment.isExternal) {
+      return 0;
+    }
+
+    const totalNodes = await this.countNodesInPath(assignment.pathRef);
+    const objectIds = await this.getLocalObjectIdsInPath(assignment.pathRef);
+    const doneCount = await this.countDoneProgressForStudent(studentId, objectIds);
+
+    return totalNodes === 0 ? 0 : Math.round((doneCount / totalNodes) * 100);
+  }
 }
 
 export default new ProgressService();

--- a/frontend/src/components/student/AssignmentOverview.tsx
+++ b/frontend/src/components/student/AssignmentOverview.tsx
@@ -19,6 +19,8 @@ export default function AssignmentOverview() {
     queryFn: fetchAssignments,
   });
 
+  console.log('Assignments:', assignments);
+
   return (
     <>
       <div className="flex flex-row gap-x-5 h-[12.5rem]  ">
@@ -56,7 +58,17 @@ export default function AssignmentOverview() {
                       <Link to={`/student/assignment/${assignmentItem.id}`}>
                         <PrimaryButton>{t('assignments.view')}</PrimaryButton>
                       </Link>
-                      {/*<p>12/50 completed</p> Replace with actual progress*/}
+                      <div className="flex items-center gap-2">
+                        <div className="w-32 h-2 bg-gray-200 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-blue-600 rounded-full transition-all duration-300"
+                            style={{ width: `${assignmentItem.progress || 0}%` }}
+                          />
+                        </div>
+                        <span className="text-sm text-gray-600">
+                          {Math.round(assignmentItem.progress || 0)}%
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/learningPath/learningPaths.tsx
+++ b/frontend/src/pages/learningPath/learningPaths.tsx
@@ -107,6 +107,9 @@ const LearningPaths: React.FC = () => {
             .sort((a, b) => a.name.localeCompare(b.name));
     }, [learningPaths]);
 
+    console.log(learningPaths ? learningPaths[0] : null);
+
+
     const uniqueLanguages = useMemo(() => {
         if (!learningPaths) return [];
         const languages = new Set(learningPaths

--- a/frontend/src/pages/learningPath/learningPaths.tsx
+++ b/frontend/src/pages/learningPath/learningPaths.tsx
@@ -57,12 +57,27 @@ const LearningPathCard: React.FC<LearningPathCardProps> = ({ path }) => {
                 )}
             </div>
             <div className="p-6 flex-grow h-40 border-t-2 border-gray-200">
-                <Link
-                    to={linkPath}
-                    className="text-blue-600 hover:text-blue-800"
-                >
-                    <h2 className="text-xl font-semibold mb-2">{path.title}</h2>
-                </Link>
+                <div className="flex justify-between items-center mb-2">
+                    <Link
+                        to={linkPath}
+                        className="text-blue-600 hover:text-blue-800"
+                    >
+                        <h2 className="text-xl font-semibold">{path.title}</h2>
+                    </Link>
+                    {!isTeacherView && (
+                        <div className="flex items-center gap-2">
+                            <div className="w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
+                                <div
+                                    className="h-full bg-blue-600 rounded-full transition-all duration-300"
+                                    style={{ width: `${path.progressPercent || 0}%` }}
+                                />
+                            </div>
+                            <span className="text-sm text-gray-600">
+                                {Math.round(path.progressPercent || 0)}%
+                            </span>
+                        </div>
+                    )}
+                </div>
                 <p className="text-gray-700 h-[77px] overflow-hidden line-clamp-3">{path.description}</p>
             </div>
         </div>
@@ -96,6 +111,8 @@ const LearningPaths: React.FC = () => {
         staleTime: 5 * 60 * 1000, // Consider data fresh for 5 minutes
         gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes
     });
+
+    console.log('Learning Paths:', learningPaths ? learningPaths.find(path => path.title === 'test') : null);
 
     const uniqueCreators = useMemo(() => {
         if (!learningPaths) return [];

--- a/frontend/src/pages/teacher/TeacherIndex.tsx
+++ b/frontend/src/pages/teacher/TeacherIndex.tsx
@@ -9,7 +9,7 @@ export default function TeacherIndex() {
   const { t } = useTranslation();
   return (
     <>
-      <div className="px-10 bg-gray-300 rounded-xl">
+      <div className="px-10 rounded-xl">
         <div className="text-6xl pt-12 font-bold">{t('home')}</div>
 
         <h2 className="mt-8 text-2xl font-bold">{t('assignments.label')}</h2>

--- a/frontend/src/util/shared/learningPath.ts
+++ b/frontend/src/util/shared/learningPath.ts
@@ -27,7 +27,7 @@ export function getAuthToken(): string | null {
 export async function fetchLearningPaths(): Promise<LearningPath[]> {
   const response = (await apiRequest({
     method: 'GET',
-    endpoint: '/learningpath?all',
+    endpoint: '/learningpath?all&includeProgress=true',
     getToken: getAuthToken,
   })) as { learningPaths: LearningPath[] };
 

--- a/frontend/src/util/student/classJoin.ts
+++ b/frontend/src/util/student/classJoin.ts
@@ -25,3 +25,7 @@ export async function fetchLeaveClass({ classId }: { classId: string }) {
     getToken: getAuthToken,
   });
 }
+
+export interface AssignmentItem {
+  progress?: number;
+}


### PR DESCRIPTION
In deze stap voeg ik een progress balk toe (en wat nodige functies aan de back end) aan de assignment en leerpaden tab. 

Testen: Maak een eigen leerpad weer manueel, voeg wat leerobjecten + nodes toe, en dan kan je de leerpad even openen, paar leerobjecten kijken zodat de progress omhoog gaat. Hierna kan men dan kijken weer op de leerpaden tab (tab met alle leerpaden dus) of de progress balk werkt. Maak dan een assignment aan met deze leerpad en zo kan je daar ook normaal gezien op de homepagina dat er een progressbalk is.