### PR TITLE
template env file fixed

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,6 @@ POSTGRES_PASSWORD=SECRET_PASSWORD
 
 DATABASE_URL="postgresql://selab2:SECRET_PASSWORD@localhost:2002/selab2?schema=public"
 
-VITE_API_URL="http://localhost:5000/"
+VITE_API_URL="http://localhost:5000"
 
 PORT=5000


### PR DESCRIPTION
In de API-URL van de template environment file stond er nog een / achter de URL. Dit zorgde ervoor dat de verkeerde routes werden gebruikt. Dit is nu opgelost.