### PR TITLE
finetunen logger

### DIFF
--- a/dwengo_backend/middleware/logResponse.ts
+++ b/dwengo_backend/middleware/logResponse.ts
@@ -23,7 +23,7 @@ const FILE_PATH_REGEX = /(?:\/[\w.-]+)+|[A-Za-z]:\\(?:[\w.-]+\\)+[\w.-]+/g;
  */
 function sanitizeResponse(obj: any): any {
   if (Array.isArray(obj)) {
-    return obj.map(sanitizeResponse);
+    return `[(length: ${obj.length})]`;
   } else if (obj && typeof obj === "object") {
     const sanitized: Record<string, any> = {};
     for (const key of Object.keys(obj)) {


### PR DESCRIPTION
Wanneer er een lijst staat in de response body, werd dit voorlopig volledig gelogd. Dit is nu opgelost door enkel de lengte van de lijst weer te geven.