### PR TITLE
Fix learning path creator filter

### DIFF
--- a/dwengo_backend/services/learningPathService.ts
+++ b/dwengo_backend/services/learningPathService.ts
@@ -25,6 +25,11 @@ export interface LearningPathDto {
 
   createdAt?: string;
   updatedAt?: string;
+  creator?: {
+    id: number;
+    firstName: string;
+    lastName: string;
+  }; // for local paths
 
   // ===== BELANGRIJK =====
   // Zodat we Dwengo vs. lokaal kunnen onderscheiden in 1 type:
@@ -45,6 +50,7 @@ function mapDwengoPathToLocal(dwengoPath: any): LearningPathDto {
     nodes: dwengoPath.nodes ?? [],
     createdAt: dwengoPath.created_at ?? "",
     updatedAt: dwengoPath.updatedAt ?? "",
+    creator: undefined, // dwengo paths don't have a specific creator
     // Nieuw: Dwengo => altijd true
     isExternal: true,
   };

--- a/frontend/src/pages/learningPath/learningPaths.tsx
+++ b/frontend/src/pages/learningPath/learningPaths.tsx
@@ -103,15 +103,16 @@ const LearningPaths: React.FC = () => {
 
   const uniqueCreators = useMemo(() => {
     if (!learningPaths) return [];
-    return Array.from(
-      new Set(
-        learningPaths
-          .filter((path) => path.creator?.user !== undefined)
-          .map((path) => ({
-            name: `${path.creator?.user.firstName} ${path.creator?.user.lastName}`,
-          })),
-      ),
-    ).sort((a, b) => a.name.localeCompare(b.name));
+    const creators = new Set(
+      learningPaths
+        .filter((path) => path.creator !== undefined)
+        .map((path) => `${path.creator?.firstName} ${path.creator?.lastName}`),
+    );
+    return Array.from(creators)
+      .map((creator) => ({
+        name: creator,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
   }, [learningPaths]);
 
   const uniqueLanguages = useMemo(() => {

--- a/frontend/src/types/type.ts
+++ b/frontend/src/types/type.ts
@@ -12,11 +12,8 @@ interface LearningPath {
   description: string;
   creator?: {
     id: string;
-    user: {
-      id: string;
-      firstName: string;
-      lastName: string;
-    };
+    firstName: string;
+    lastName: string;
   };
   createdAt: string;
   updatedAt: string;

--- a/frontend/src/util/filter.tsx
+++ b/frontend/src/util/filter.tsx
@@ -1,52 +1,66 @@
-import { Filter, FilterType } from "@/components/ui/filters";
-import { LearningPath } from "@/types/type";
+import { Filter, FilterType } from '@/components/ui/filters';
+import { LearningPath } from '@/types/type';
 
-export function filterLearningPaths(paths: LearningPath[],
-    filters: Filter[],
-    searchQuery: string
+export function filterLearningPaths(
+  paths: LearningPath[],
+  filters: Filter[],
+  searchQuery: string,
 ): LearningPath[] {
-    if (!paths) return [];
-    return paths.filter(path => {
-        // First check the search query
-        if (searchQuery && !path.title.toLowerCase().includes(searchQuery.toLowerCase())) {
-            return false;
-        }
-        // If no filters are applied, show all paths that match the search
-        if (filters.length === 0) return true;
-        // Check if path matches all active filters
-        return filters.every(filter => {
-            switch (filter.type) {
-                case FilterType.LANGUAGE:
-                    if (filter.value.length === 0) return true;
-                    // Check if the path's language matches the selected languages
-                    if (path.language === null) return false; // Handle null language
-                    // Check if any of the selected languages match the path's language
-                    return filter.value.length === 0 || filter.value.includes(path.language);
-                case FilterType.CREATED_DATE:
-                    if (filter.value.length === 0) return true;
-                    const pathDate = new Date(path.createdAt);
-                    if (isNaN(pathDate.getTime())) return false; // Invalid date
-                    const now = new Date();
-                    const diffDays = Math.floor((now.getTime() - pathDate.getTime()) / (1000 * 60 * 60 * 24));
+  if (!paths) return [];
+  return paths.filter((path) => {
+    // First check the search query
+    if (
+      searchQuery &&
+      !path.title.toLowerCase().includes(searchQuery.toLowerCase())
+    ) {
+      return false;
+    }
+    // If no filters are applied, show all paths that match the search
+    if (filters.length === 0) return true;
+    // Check if path matches all active filters
+    return filters.every((filter) => {
+      switch (filter.type) {
+        case FilterType.LANGUAGE:
+          if (filter.value.length === 0) return true;
+          // Check if the path's language matches the selected languages
+          if (path.language === null) return false; // Handle null language
+          // Check if any of the selected languages match the path's language
+          return (
+            filter.value.length === 0 || filter.value.includes(path.language)
+          );
+        case FilterType.CREATED_DATE: {
+          if (filter.value.length === 0) return true;
+          const pathDate = new Date(path.createdAt);
+          if (isNaN(pathDate.getTime())) return false; // Invalid date
+          const now = new Date();
+          const diffDays = Math.floor(
+            (now.getTime() - pathDate.getTime()) / (1000 * 60 * 60 * 24),
+          );
 
-                    return filter.value.some(value => {
-                        switch (value) {
-                            case 'week': return diffDays <= 7;
-                            case 'month': return diffDays <= 30;
-                            case 'year': return diffDays <= 365;
-                            default: return true;
-                        }
-                    });
-                case FilterType.CREATOR:
-                    if (filter.value.length === 0) return true;
-                    if (!path.creator?.user?.firstName || !path.creator?.user?.lastName) return false;
-                    const creatorFullName = `${path.creator.user.firstName} ${path.creator.user.lastName}`;
-                    // Check if any of the selected creators match the path's creator full name
-                    return filter.value.some(v => creatorFullName === v);
-
-                default:
-                    return true;
+          return filter.value.some((value) => {
+            switch (value) {
+              case 'week':
+                return diffDays <= 7;
+              case 'month':
+                return diffDays <= 30;
+              case 'year':
+                return diffDays <= 365;
+              default:
+                return true;
             }
-        });
+          });
+        }
+        case FilterType.CREATOR: {
+          if (filter.value.length === 0) return true;
+          if (!path.creator?.firstName || !path.creator?.lastName) return false;
+          const creatorFullName = `${path.creator.firstName} ${path.creator.lastName}`;
+          // Check if any of the selected creators match the path's creator full name
+          return filter.value.some((v) => creatorFullName === v);
+        }
+
+        default:
+          return true;
+      }
     });
+  });
 }

--- a/frontend/src/util/shared/learningPath.ts
+++ b/frontend/src/util/shared/learningPath.ts
@@ -18,7 +18,6 @@ export function getAuthToken(): string | null {
   return token;
 }
 
-
 /**
  * Fetches all learning paths for the authenticated teacher
  * @returns {Promise<LearningPath[]>} List of learning paths
@@ -29,16 +28,14 @@ export async function fetchLearningPaths(): Promise<LearningPath[]> {
     method: 'GET',
     endpoint: '/learningpath?all',
     getToken: getAuthToken,
-  })) as { learningPaths: LearningPath[] };
+  })) as LearningPath[];
 
   return response
     .map((path: any) => ({
       ...path,
       id: path._id || path.id,
     }))
-    .sort((a: LearningPath, b: LearningPath) =>
-      a.title.localeCompare(b.title),
-    ) as LearningPath[];
+    .sort((a: LearningPath, b: LearningPath) => a.title.localeCompare(b.title));
 }
 
 /**
@@ -52,7 +49,6 @@ export async function fetchLearningPath(
   learningPathId: string,
   isExternal: boolean = false,
 ): Promise<LearningPath> {
-
   return (await apiRequest({
     method: 'GET',
     endpoint: `/learningpath/${learningPathId}?includeProgress=true`,


### PR DESCRIPTION
De optie om te filteren op leerpad creator was kapot omdat vanuit de backend de creator niet meer werd meegegeven. 
Ik heb dit dus aangepast en gezorgd dat frontend dat dan ook correct gebruikt.
Bovendien toonde de filter ook niet correct unieke creators, maar stonden dezelfde namen er meerdere keren in, dus dat heb ik ook aangepast.