### PR TITLE
Fix/testen falen op develop

### DIFF
--- a/dwengo_backend/tests/integratie/assignment.test.ts
+++ b/dwengo_backend/tests/integratie/assignment.test.ts
@@ -22,7 +22,7 @@ describe("Assignment test", (): void => {
     const nonExistentId = 123;
     it("should return 404 when the assignment isn't found", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/assignment/${nonExistentId}`)
+        .get(`/api/assignment/${nonExistentId}`)
         .set(getAuthHeaders(teacherUser1));
 
       expect(status).toBe(404);

--- a/dwengo_backend/tests/integratie/auth.test.ts
+++ b/dwengo_backend/tests/integratie/auth.test.ts
@@ -8,7 +8,7 @@ describe("Authentication API Tests", () => {
   describe("[POST] /auth/student/register", () => {
     it("should register a new student", async () => {
       const response = await request(app)
-        .post("/auth/student/register")
+        .post("/api/auth/student/register")
         .send({
           firstName: "Jan",
           lastName: "Jansen",
@@ -37,7 +37,7 @@ describe("Authentication API Tests", () => {
     });
     it("should respond with `400` when some fields are missing", async () => {
       const response = await request(app)
-        .post("/auth/student/register")
+        .post("/api/auth/student/register")
         .send({}); // empty body
 
       expect(response.status).toBe(400);
@@ -68,7 +68,7 @@ describe("Authentication API Tests", () => {
       });
     });
     it("should respond with `400` when email is invalid", async () => {
-      const response = await request(app).post("/auth/student/register").send({
+      const response = await request(app).post("/api/auth/student/register").send({
         firstName: "Jan",
         lastName: "Jansen",
         email: "invaidemail",
@@ -91,7 +91,7 @@ describe("Authentication API Tests", () => {
       });
     });
     it("should respond with `400` when password is too short", async () => {
-      const response = await request(app).post("/auth/student/register").send({
+      const response = await request(app).post("/api/auth/student/register").send({
         firstName: "Jan",
         lastName: "Jansen",
         email: "student1@example.com",
@@ -122,7 +122,7 @@ describe("Authentication API Tests", () => {
       );
 
       // test creating a new student with the same email
-      const response = await request(app).post("/auth/student/register").send({
+      const response = await request(app).post("/api/auth/student/register").send({
         firstName: "Bob",
         lastName: "Bobsen",
         email: studentUser.email,
@@ -149,7 +149,7 @@ describe("Authentication API Tests", () => {
       );
 
       // test creating a new student with the same email
-      const response = await request(app).post("/auth/student/register").send({
+      const response = await request(app).post("/api/auth/student/register").send({
         firstName: "Bob",
         lastName: "Bobsen",
         email: teacherUser.email,
@@ -169,7 +169,7 @@ describe("Authentication API Tests", () => {
     });
     it("should convert emails to lower case", async () => {
       // create a student with an uppercase email
-      const response = await request(app).post("/auth/student/register").send({
+      const response = await request(app).post("/api/auth/student/register").send({
         firstName: "Jan",
         lastName: "Jansen",
         email: "TEST@EXAMPLE.COM",
@@ -189,7 +189,7 @@ describe("Authentication API Tests", () => {
     beforeEach(async () => {
       // register a student
       await request(app)
-        .post("/auth/student/register")
+        .post("/api/auth/student/register")
         .send({
           firstName: "Jan",
           lastName: "Jansen",
@@ -201,7 +201,7 @@ describe("Authentication API Tests", () => {
     it("should login with registered student credentials", async () => {
       // test logging in
       const response = await request(app)
-        .post("/auth/student/login")
+        .post("/api/auth/student/login")
         .send({
           email: "student1@example.com",
           password: "password123",
@@ -213,7 +213,7 @@ describe("Authentication API Tests", () => {
     it("should log in, even if the email is in uppercase", async () => {
       // test logging in with email in uppercase
       const response = await request(app)
-        .post("/auth/student/login")
+        .post("/api/auth/student/login")
         .send({
           email: "StUdEnt1@eXAmpLe.COm",
           password: "password123",
@@ -224,7 +224,7 @@ describe("Authentication API Tests", () => {
     });
     it("should fail login with non-registered email", async () => {
       const response = await request(app)
-        .post("/auth/student/login")
+        .post("/api/auth/student/login")
         .send({
           email: "nietbestaande@student.com",
           password: "password123",
@@ -237,7 +237,7 @@ describe("Authentication API Tests", () => {
     });
     it("should fail login with correct email but wrong password", async () => {
       const response = await request(app)
-        .post("/auth/student/login")
+        .post("/api/auth/student/login")
         .send({
           email: "student1@example.com",
           password: "wrongpassword",
@@ -249,7 +249,7 @@ describe("Authentication API Tests", () => {
       expect(response.body.message).toBe("Incorrect password.");
     });
     it("should fail if request body is incorrect", async () => {
-      const response = await request(app).post("/auth/student/login").send({}); // empty body
+      const response = await request(app).post("/api/auth/student/login").send({}); // empty body
 
       expect(response.status).toBe(400);
       expect(response.body.details).toEqual(
@@ -271,7 +271,7 @@ describe("Authentication API Tests", () => {
   describe("[POST] /auth/teacher/register", () => {
     it("should register a new teacher", async () => {
       const response = await request(app)
-        .post("/auth/teacher/register")
+        .post("/api/auth/teacher/register")
         .send({
           firstName: "Piet",
           lastName: "Pietersen",
@@ -300,7 +300,7 @@ describe("Authentication API Tests", () => {
     });
     it("should respond with `400` when some fields are missing", async () => {
       const response = await request(app)
-        .post("/auth/teacher/register")
+        .post("/api/auth/teacher/register")
         .send({}); // empty body
 
       expect(response.status).toBe(400);
@@ -331,7 +331,7 @@ describe("Authentication API Tests", () => {
       });
     });
     it("should respond with `400` when email is invalid", async () => {
-      const response = await request(app).post("/auth/teacher/register").send({
+      const response = await request(app).post("/api/auth/teacher/register").send({
         firstName: "Jan",
         lastName: "Jansen",
         email: "invaidemail",
@@ -354,7 +354,7 @@ describe("Authentication API Tests", () => {
       });
     });
     it("should respond with `400` when password is too short", async () => {
-      const response = await request(app).post("/auth/teacher/register").send({
+      const response = await request(app).post("/api/auth/teacher/register").send({
         firstName: "Jan",
         lastName: "Jansen",
         email: "student1@example.com",
@@ -385,7 +385,7 @@ describe("Authentication API Tests", () => {
       );
 
       // test creating a new teacher with the same email
-      const response = await request(app).post("/auth/teacher/register").send({
+      const response = await request(app).post("/api/auth/teacher/register").send({
         firstName: "Bob",
         lastName: "Bobsen",
         email: studentUser.email,
@@ -412,7 +412,7 @@ describe("Authentication API Tests", () => {
       );
 
       // test creating a new teacher with the same email
-      const response = await request(app).post("/auth/teacher/register").send({
+      const response = await request(app).post("/api/auth/teacher/register").send({
         firstName: "Bob",
         lastName: "Bobsen",
         email: teacherUser.email,
@@ -432,7 +432,7 @@ describe("Authentication API Tests", () => {
     });
     it("should convert emails to lowercase", async () => {
       // create a teacher with an uppercase email
-      const response = await request(app).post("/auth/teacher/register").send({
+      const response = await request(app).post("/api/auth/teacher/register").send({
         firstName: "Jan",
         lastName: "Jansen",
         email: "TEST@EXAMPLE.COM",
@@ -451,7 +451,7 @@ describe("Authentication API Tests", () => {
   describe("[POST] /auth/teacher/login", () => {
     beforeEach(async () => {
       // register a teacher
-      await request(app).post("/auth/teacher/register").send({
+      await request(app).post("/api/auth/teacher/register").send({
         firstName: "Piet",
         lastName: "Pietersen",
         email: "teacher1@example.com",
@@ -460,7 +460,7 @@ describe("Authentication API Tests", () => {
     });
     it("should login with registered teacher credentials", async () => {
       const response = await request(app)
-        .post("/auth/teacher/login")
+        .post("/api/auth/teacher/login")
         .send({
           email: "teacher1@example.com",
           password: "password123",
@@ -472,7 +472,7 @@ describe("Authentication API Tests", () => {
     it("should log in, even if the email is in uppercase", async () => {
       // test logging in with email in uppercase
       const response = await request(app)
-        .post("/auth/teacher/login")
+        .post("/api/auth/teacher/login")
         .send({
           email: "teACHer1@eXAMple.cOm",
           password: "password123",
@@ -483,7 +483,7 @@ describe("Authentication API Tests", () => {
     });
     it("should fail login with non-registered email", async () => {
       const response = await request(app)
-        .post("/auth/teacher/login")
+        .post("/api/auth/teacher/login")
         .send({
           email: "nietbestaande@teacher.com",
           password: "password123",
@@ -496,7 +496,7 @@ describe("Authentication API Tests", () => {
     });
     it("should fail login with correct email but wrong password", async () => {
       const response = await request(app)
-        .post("/auth/teacher/login")
+        .post("/api/auth/teacher/login")
         .send({
           email: "teacher1@example.com",
           password: "wrongpassword",
@@ -508,7 +508,7 @@ describe("Authentication API Tests", () => {
       expect(response.body.message).toBe("Incorrect password.");
     });
     it("should fail if request body is incorrect", async () => {
-      const response = await request(app).post("/auth/teacher/login").send({}); // empty body
+      const response = await request(app).post("/api/auth/teacher/login").send({}); // empty body
 
       expect(response.status).toBe(400);
       expect(response.body.details).toEqual(

--- a/dwengo_backend/tests/integratie/class.test.ts
+++ b/dwengo_backend/tests/integratie/class.test.ts
@@ -65,7 +65,7 @@ describe("classroom tests", (): void => {
 
       // now test getting the classrooms
       const { status, body } = await request(app)
-        .get("/class/teacher")
+        .get("/api/class/teacher")
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);
@@ -92,7 +92,7 @@ describe("classroom tests", (): void => {
       );
 
       const { status, body } = await request(app)
-        .get("/class/teacher")
+        .get("/api/class/teacher")
         .set("Authorization", `Bearer ${studentUser.token}`);
 
       expect(body.classrooms).not.toBeDefined();
@@ -118,7 +118,7 @@ describe("classroom tests", (): void => {
 
       // now test getting the classrooms
       const { status, body } = await request(app)
-        .get("/class/student")
+        .get("/api/class/student")
         .set("Authorization", `Bearer ${studentUser.token}`);
 
       expect(status).toBe(200);
@@ -127,7 +127,7 @@ describe("classroom tests", (): void => {
 
     it("shouldn't allow a teacher to get the classes via the student route", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/class/student")
+        .get("/api/class/student")
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(body.classrooms).not.toBeDefined();
@@ -140,7 +140,7 @@ describe("classroom tests", (): void => {
   describe("[POST] /class/teacher", (): void => {
     it("should respond with a `201` status code and a created class", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .post("/class/teacher")
+        .post("/api/class/teacher")
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({ name: "6A" });
 
@@ -163,7 +163,7 @@ describe("classroom tests", (): void => {
 
     it("should respond with a `400` status code and a message when no valid class name is provided", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .post("/class/teacher")
+        .post("/api/class/teacher")
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({ name: "" });
 
@@ -181,7 +181,7 @@ describe("classroom tests", (): void => {
         "aaaaa@gmail.com",
       );
       const { status, body } = await request(app)
-        .post("/class/teacher")
+        .post("/api/class/teacher")
         .set("Authorization", `Bearer ${studentUser.token}`)
         .send({ name: "6A" });
 
@@ -239,7 +239,7 @@ describe("classroom tests", (): void => {
 
       // now test deleting the class
       const { status } = await request(app)
-        .delete(`/class/teacher/${classroom.id}`)
+        .delete(`/api/class/teacher/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(204);
@@ -256,7 +256,7 @@ describe("classroom tests", (): void => {
     it("should respond with a `403` status code and a message when the teacher is not associated with the class", async (): Promise<void> => {
       // try having a teacher delete a class they are not associated with
       const { status, body } = await request(app)
-        .delete(`/class/teacher/${classroom.id}`)
+        .delete(`/api/class/teacher/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`); // teacherUser1 is not associated with the class
 
       expect(status).toBe(403);
@@ -276,7 +276,7 @@ describe("classroom tests", (): void => {
       // add teacherUser1 to class, so we can test getting the join link
       await addTeacherToClass(teacherUser1.id, classroom.id);
       let { status, body } = await request(app)
-        .get(`/class/teacher/${classroom.id}/join-link`)
+        .get(`/api/class/teacher/${classroom.id}/join-link`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);
@@ -293,7 +293,7 @@ describe("classroom tests", (): void => {
         "aaaaa@gmail.com",
       );
       ({ status, body } = await request(app)
-        .post(`/join-request/student?joinCode=${classroom.code}`) // can't use body.joinLink here, because the APP_URL is different in the test environment
+        .post(`/api/join-request/student?joinCode=${classroom.code}`) // can't use body.joinLink here, because the APP_URL is different in the test environment
         .set("Authorization", `Bearer ${studentUser.token}`));
 
       expect(status).toBe(201);
@@ -304,7 +304,7 @@ describe("classroom tests", (): void => {
     it("should respond with a `403` status code and a message when the teacher is not associated with the class", async (): Promise<void> => {
       // try getting the join link for a class the teacher is not associated with
       const { status, body } = await request(app)
-        .get(`/class/teacher/${classroom.id}/join-link`)
+        .get(`/api/class/teacher/${classroom.id}/join-link`)
         .set("Authorization", `Bearer ${teacherUser1.token}`); // teacherUser1 is not associated with the class
 
       expect(status).toBe(403);
@@ -323,7 +323,7 @@ describe("classroom tests", (): void => {
       const invalidClassId: number = (maxClass?.id ?? 0) + 1;
 
       const { status, body } = await request(app)
-        .get(`/class/teacher/${invalidClassId}/join-link`)
+        .get(`/api/class/teacher/${invalidClassId}/join-link`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(404);
@@ -338,7 +338,7 @@ describe("classroom tests", (): void => {
       // add teacherUser1 to class, so we can test regenerating the join link
       await addTeacherToClass(teacherUser1.id, classroom.id);
       const { status, body } = await request(app)
-        .patch(`/class/teacher/${classroom.id}/join-link`)
+        .patch(`/api/class/teacher/${classroom.id}/join-link`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);
@@ -355,7 +355,7 @@ describe("classroom tests", (): void => {
 
     it("should respond with a `403` status code and a message when the teacher is not associated with the class", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .patch(`/class/teacher/${classroom.id}/join-link`)
+        .patch(`/api/class/teacher/${classroom.id}/join-link`)
         .set("Authorization", `Bearer ${teacherUser1.token}`); // teacherUser1 is not associated with the class
 
       expect(status).toBe(403);
@@ -373,7 +373,7 @@ describe("classroom tests", (): void => {
       const invalidClassId: number = (maxClass?.id ?? 0) + 1;
 
       const { status, body } = await request(app)
-        .patch(`/class/teacher/${invalidClassId}/join-link`)
+        .patch(`/api/class/teacher/${invalidClassId}/join-link`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(404);
@@ -405,7 +405,7 @@ describe("classroom tests", (): void => {
 
       // now test getting the students
       const { status, body } = await request(app)
-        .get(`/class/teacher/${classroom.id}/student`)
+        .get(`/api/class/teacher/${classroom.id}/student`)
         .set("Authorization", `Bearer ${teacherUser1.token}`); // teacherUser1 is associated with the class
 
       // verify the response
@@ -416,7 +416,7 @@ describe("classroom tests", (): void => {
     it("should respond with a `403` status code when the teacher is not associated with the class", async (): Promise<void> => {
       // try getting the students for a class the teacher is not associated with
       const { status, body } = await request(app)
-        .get(`/class/teacher/${classroom.id}/student`)
+        .get(`/api/class/teacher/${classroom.id}/student`)
         .set("Authorization", `Bearer ${teacherUser1.token}`); // teacherUser1 is not associated with the class
 
       expect(status).toBe(403);
@@ -439,7 +439,7 @@ describe("classroom tests", (): void => {
 
       // now test leaving the class
       const { status, body } = await request(app)
-        .delete(`/class/student/${c.id}`)
+        .delete(`/api/class/student/${c.id}`)
         .set("Authorization", `Bearer ${s.token}`);
       expect(status).toBe(204);
       expect(body).toEqual({});
@@ -473,7 +473,7 @@ describe("classroom tests", (): void => {
       const c: Class = await createClass("LATA", "EFGH");
 
       const { status, body } = await request(app)
-        .delete(`/class/student/${c.id}`)
+        .delete(`/api/class/student/${c.id}`)
         .set("Authorization", `Bearer ${s.token}`);
 
       expect(status).toBe(400);
@@ -488,7 +488,7 @@ describe("classroom tests", (): void => {
 
     it("should respond with a `200` status code and the specified class", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/class/student/${classroom1.id}`)
+        .get(`/api/class/student/${classroom1.id}`)
         .set("Authorization", `Bearer ${student1.token}`);
       expect(status).toBe(200);
       expect(body.name).toBe(classroom1.name);
@@ -498,12 +498,12 @@ describe("classroom tests", (): void => {
 
     it("should return the same class for students that are in the same class", async (): Promise<void> => {
       const res = await request(app)
-        .get(`/class/student/${classroom1.id}`)
+        .get(`/api/class/student/${classroom1.id}`)
         .set("Authorization", `Bearer ${student1.token}`);
       expect(res.status).toBe(200);
 
       const res2 = await request(app)
-        .get(`/class/student/${classroom1.id}`)
+        .get(`/api/class/student/${classroom1.id}`)
         .set("Authorization", `Bearer ${student2.token}`);
       expect(res2.status).toBe(200);
       expect(res2.body).toEqual(res.body);
@@ -511,7 +511,7 @@ describe("classroom tests", (): void => {
 
     it("should respond with a `403` status code because the student is not a part of the class", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/class/student/${classroom2.id}`)
+        .get(`/api/class/student/${classroom2.id}`)
         .set("Authorization", `Bearer ${student2.token}`);
 
       expect(status).toBe(403);

--- a/dwengo_backend/tests/integratie/feedback.test.ts
+++ b/dwengo_backend/tests/integratie/feedback.test.ts
@@ -111,7 +111,7 @@ describe("Feedback tests", (): void => {
       // In deze test wordt nagegaan dat je geen feedback kan geven op een submission van een assignment
       // waarvan de deadline nog niet verstreken is
       const { status, body } = await request(app)
-        .post(`/feedback/submission/${onGoingAssignmentSubmissionId}`)
+        .post(`/api/feedback/submission/${onGoingAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(403);
@@ -130,7 +130,7 @@ describe("Feedback tests", (): void => {
     it("Should respond with a `401` status (UnauthorizedError)", async (): Promise<void> => {
       // In deze test wordt nagegaan dat je geen feedback kunt geven als student
       const { status, body } = await request(app)
-        .post(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .post(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${student.token}`);
 
       expect(status).toBe(401);
@@ -146,7 +146,7 @@ describe("Feedback tests", (): void => {
 
     it("Should respond with a `201` status and the created feedback", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .post(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .post(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${teacher.token}`)
         .send({ description: "Mooie oplossing!" });
 
@@ -162,7 +162,7 @@ describe("Feedback tests", (): void => {
 
     it("Should respond with a `400` status when the submission id is not a valid number", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .post(`/feedback/submission/notANumber`)
+        .post(`/api/feedback/submission/notANumber`)
         .set("Authorization", `Bearer ${teacher.token}`)
         .send({ description: "Mooie oplossing!" });
 
@@ -177,7 +177,7 @@ describe("Feedback tests", (): void => {
       const newTeacher: User & { teacher: Teacher; token: string } =
         await createTeacher("new", "teacher", "newteacher@gmail.com");
       const { status, body } = await request(app)
-        .post(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .post(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${newTeacher.token}`);
 
       expect(status).toBe(403);
@@ -198,7 +198,7 @@ describe("Feedback tests", (): void => {
       );
 
       const { status, body } = await request(app)
-        .get(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .get(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(200);
@@ -208,7 +208,7 @@ describe("Feedback tests", (): void => {
     it("Should respond with a `404` status and saying it found no feedback", async (): Promise<void> => {
       // Check if this returns a 404 when searching for feedback that does not yet exist
       const { status, body } = await request(app)
-        .get(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .get(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(404);
@@ -218,7 +218,7 @@ describe("Feedback tests", (): void => {
 
     it("Should respond with a `400` status when the ID is not a number", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/feedback/submission/notANumber`)
+        .get(`/api/feedback/submission/notANumber`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(400);
@@ -235,7 +235,7 @@ describe("Feedback tests", (): void => {
       );
 
       const { status, body } = await request(app)
-        .get(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .get(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${student.token}`);
 
       expect(status).toBe(401);
@@ -255,7 +255,7 @@ describe("Feedback tests", (): void => {
         await createTeacher("new", "teacher", "newteacher@gmail.com");
 
       const { status, body } = await request(app)
-        .get(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .get(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${newTeacher.token}`);
 
       expect(status).toBe(403);
@@ -271,7 +271,7 @@ describe("Feedback tests", (): void => {
       const assignmentIdFromOtherClass = 123;
       const { status, body } = await request(app)
         .get(
-          `/feedback/assignment/${assignmentIdFromOtherClass}/evaluation/${evalId}`,
+          `/api/feedback/assignment/${assignmentIdFromOtherClass}/evaluation/${evalId}`,
         )
         .set("Authorization", `Bearer ${teacher.token}`);
 
@@ -285,7 +285,7 @@ describe("Feedback tests", (): void => {
     it("Should respond with a `401` status when a student tries to access the information", async (): Promise<void> => {
       const { status, body } = await request(app)
         .get(
-          `/feedback/assignment/${passedAssignmentSubmissionId}/evaluation/${evalId}`,
+          `/api/feedback/assignment/${passedAssignmentSubmissionId}/evaluation/${evalId}`,
         )
         .set("Authorization", `Bearer ${student.token}`);
 
@@ -316,7 +316,7 @@ describe("Feedback tests", (): void => {
       );
 
       const { status, body } = await request(app)
-        .get(`/feedback/assignment/${passedAssignmentId}/evaluation/${evalId}`)
+        .get(`/api/feedback/assignment/${passedAssignmentId}/evaluation/${evalId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(200);
@@ -327,7 +327,7 @@ describe("Feedback tests", (): void => {
   describe("[PATCH] /feedback/submission/:submissionId", (): void => {
     it("Should respond with a `401` status code (Unauthorized user - student)", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .patch(`/feedback/submission/:submissionId`)
+        .patch(`/api/feedback/submission/:submissionId`)
         .set("Authorization", `Bearer ${student.token}`);
 
       expect(status).toBe(401);
@@ -337,7 +337,7 @@ describe("Feedback tests", (): void => {
 
     it("Should respond with a `400` status code when the submissionID is not valid", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .patch(`/feedback/submission/invalidSubmissionId`)
+        .patch(`/api/feedback/submission/invalidSubmissionId`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(400);
@@ -354,7 +354,7 @@ describe("Feedback tests", (): void => {
       );
 
       const { status, body } = await request(app)
-        .patch(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .patch(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${teacher.token}`)
         .send({ description: "Zeer netjes!" });
 
@@ -365,7 +365,7 @@ describe("Feedback tests", (): void => {
 
     it("Should respond with a `404` status code when updating feedback that does not exist", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .patch(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .patch(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${teacher.token}`)
         .send({ description: "Zeer netjes!" });
 
@@ -379,7 +379,7 @@ describe("Feedback tests", (): void => {
         await createTeacher("new", "teacher", "newteacher@gmail.com");
 
       const { status, body } = await request(app)
-        .patch(`/feedback/submission/176`)
+        .patch(`/api/feedback/submission/176`)
         .set("Authorization", `Bearer ${newTeacher.token}`);
 
       expect(status).toBe(403);
@@ -400,7 +400,7 @@ describe("Feedback tests", (): void => {
       );
 
       const { status, body } = await request(app)
-        .delete(`/feedback/submission/${onGoingAssignmentSubmissionId}`)
+        .delete(`/api/feedback/submission/${onGoingAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(204);
@@ -418,7 +418,7 @@ describe("Feedback tests", (): void => {
 
     it("Should respond with a `404` status code when trying to delete feedback that doesn't exist", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .delete(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .delete(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(404);
@@ -428,7 +428,7 @@ describe("Feedback tests", (): void => {
 
     it("Should respond with a `400` status code when :submissionId is not valid", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .delete(`/feedback/submission/invalidId`)
+        .delete(`/api/feedback/submission/invalidId`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(400);
@@ -438,7 +438,7 @@ describe("Feedback tests", (): void => {
 
     it("Should respond with a `401` status code when a student tries to delete something", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .delete(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .delete(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${student.token}`);
 
       expect(status).toBe(401);
@@ -450,7 +450,7 @@ describe("Feedback tests", (): void => {
       const newTeacher: User & { teacher: Teacher; token: string } =
         await createTeacher("new", "teacher", "newteacher@gmail.com");
       const { status, body } = await request(app)
-        .delete(`/feedback/submission/${passedAssignmentSubmissionId}`)
+        .delete(`/api/feedback/submission/${passedAssignmentSubmissionId}`)
         .set("Authorization", `Bearer ${newTeacher.token}`);
 
       expect(status).toBe(403);

--- a/dwengo_backend/tests/integratie/invite.test.ts
+++ b/dwengo_backend/tests/integratie/invite.test.ts
@@ -33,7 +33,7 @@ describe("invite tests", async (): Promise<void> => {
 
   async function sendInvitationToTeacherAndCheckExistence(): Promise<void> {
     const { status, body } = await request(app)
-      .post(`/invite/class/${classroom.id}`)
+      .post(`/api/invite/class/${classroom.id}`)
       .set("Authorization", `Bearer ${teacherUser1.token}`)
       .send({
         otherTeacherEmail: teacherUser2.email,
@@ -92,7 +92,7 @@ describe("invite tests", async (): Promise<void> => {
       const invalidClassId: number = (maxClass?.id ?? 0) + 1;
       // try to create invite for non-existent class
       const { status, body } = await request(app)
-        .post(`/invite/class/${invalidClassId}`)
+        .post(`/api/invite/class/${invalidClassId}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({
           otherTeacherEmail: teacherUser2.email,
@@ -111,7 +111,7 @@ describe("invite tests", async (): Promise<void> => {
       // we can use the existing scenario with two valid teachers and a class, but none of them are a teacher of the class
       // try to create invite for class where teacher1 is not a teacher
       const { status, body } = await request(app)
-        .post(`/invite/class/${classroom.id}`)
+        .post(`/api/invite/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({
           otherTeacherEmail: teacherUser2.email,
@@ -133,7 +133,7 @@ describe("invite tests", async (): Promise<void> => {
 
       // try to create the invite
       const { status, body } = await request(app)
-        .post(`/invite/class/${classroom.id}`)
+        .post(`/api/invite/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({
           otherTeacherEmail: teacherUser2.email,
@@ -153,7 +153,7 @@ describe("invite tests", async (): Promise<void> => {
       await addTeacherToClass(teacherUser1.id, classroom.id);
       // send a first invite
       await request(app)
-        .post(`/invite/class/${classroom.id}`)
+        .post(`/api/invite/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({
           otherTeacherEmail: teacherUser2.email,
@@ -166,7 +166,7 @@ describe("invite tests", async (): Promise<void> => {
 
       // try to create another invite for the same class and teacher
       const { status, body } = await request(app)
-        .post(`/invite/class/${classroom.id}`)
+        .post(`/api/invite/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({
           otherTeacherEmail: teacherUser2.email,
@@ -186,7 +186,7 @@ describe("invite tests", async (): Promise<void> => {
     it("should respond with a `400` status code when request body/params are incorrect", async (): Promise<void> => {
       // try to create an invitation with an invalid body and params
       const { status, body } = await request(app)
-        .post(`/invite/class/invalid_id`)
+        .post(`/api/invite/class/invalid_id`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({
           otherTeacherEmail: "sldk",
@@ -215,7 +215,7 @@ describe("invite tests", async (): Promise<void> => {
     it("should respond with a `400` status code when the request body is missing", async (): Promise<void> => {
       await addTeacherToClass(teacherUser1.id, classroom.id);
       const { status: status, body: body } = await request(app)
-        .post(`/invite/class/${classroom.id}`)
+        .post(`/api/invite/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({}); // empty body
 
@@ -240,7 +240,7 @@ describe("invite tests", async (): Promise<void> => {
     it("should respond with a `404` status code when the teacher does not exist", async (): Promise<void> => {
       await addTeacherToClass(teacherUser1.id, classroom.id);
       const { status, body } = await request(app)
-        .post(`/invite/class/${classroom.id}`)
+        .post(`/api/invite/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({
           otherTeacherEmail: "ikbestaniet@gmail.com",
@@ -263,7 +263,7 @@ describe("invite tests", async (): Promise<void> => {
       const student: User & { student: Student; token: string } =
         await createStudent("new", "student", "newstudent@gmail.com");
       const { status, body } = await request(app)
-        .post(`/invite/class/${classroom.id}`)
+        .post(`/api/invite/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send({
           otherTeacherEmail: student.email,
@@ -299,7 +299,7 @@ describe("invite tests", async (): Promise<void> => {
       );
 
       const { status, body } = await request(app)
-        .get("/invite")
+        .get("/api/invite")
         .set("Authorization", `Bearer ${teacherUser2.token}`);
 
       expect(status).toBe(200);
@@ -322,7 +322,7 @@ describe("invite tests", async (): Promise<void> => {
     it("should respond with a `200` status code and an updated invite when the action is `accept`", async (): Promise<void> => {
       // we've got a scenario with a valid pending invite, test accepting it
       const { status, body } = await request(app)
-        .patch(`/invite/${invite.inviteId}`)
+        .patch(`/api/invite/${invite.inviteId}`)
         .set("Authorization", `Bearer ${teacherUser2.token}`)
         .send({
           action: "accept",
@@ -346,7 +346,7 @@ describe("invite tests", async (): Promise<void> => {
     it("should respond with a `200` status code and an updated invite when the action is `decline`", async (): Promise<void> => {
       // we've got a scenario with a valid pending invite, test declining it
       const { status, body } = await request(app)
-        .patch(`/invite/${invite.inviteId}`)
+        .patch(`/api/invite/${invite.inviteId}`)
         .set("Authorization", `Bearer ${teacherUser2.token}`)
         .send({
           action: "decline",
@@ -368,7 +368,7 @@ describe("invite tests", async (): Promise<void> => {
     it("should respond with a `400` status code when the action is neither `accept` nor `decline`", async (): Promise<void> => {
       // we've got a scenario with a valid pending invite, test invalid action
       const { status, body } = await request(app)
-        .patch(`/invite/${invite.inviteId}`)
+        .patch(`/api/invite/${invite.inviteId}`)
         .set("Authorization", `Bearer ${teacherUser2.token}`)
         .send({
           action: "invalid_action",
@@ -415,7 +415,7 @@ describe("invite tests", async (): Promise<void> => {
       });
       // now let's try to accept the non-existent invite
       const { status, body } = await request(app)
-        .patch(`/invite/${invite.inviteId}`)
+        .patch(`/api/invite/${invite.inviteId}`)
         .set("Authorization", `Bearer ${teacherUser2.token}`)
         .send({
           action: "accept",
@@ -446,7 +446,7 @@ describe("invite tests", async (): Promise<void> => {
       });
       // now let's try to accept the invite
       const { status, body } = await request(app)
-        .patch(`/invite/${invite.inviteId}`)
+        .patch(`/api/invite/${invite.inviteId}`)
         .set("Authorization", `Bearer ${teacherUser2.token}`)
         .send({
           action: "accept",
@@ -467,7 +467,7 @@ describe("invite tests", async (): Promise<void> => {
     it("should respond with a `400` status code when the inviteId param is not a positive integer", async (): Promise<void> => {
       // try to update an invitation with an invalid inviteId
       const { status, body } = await request(app)
-        .patch(`/invite/invalid_id`)
+        .patch(`/api/invite/invalid_id`)
         .set("Authorization", `Bearer ${teacherUser2.token}`)
         .send({
           action: "accept",
@@ -502,7 +502,7 @@ describe("invite tests", async (): Promise<void> => {
     it("should respond with a `204` status code", async (): Promise<void> => {
       // test deleting the invite
       const { status } = await request(app)
-        .delete(`/invite/${invite.inviteId}/class/${classroom.id}`)
+        .delete(`/api/invite/${invite.inviteId}/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(204);
@@ -513,7 +513,7 @@ describe("invite tests", async (): Promise<void> => {
       const teacherUser3: User & { teacher: Teacher; token: string } =
         await createTeacher("Jane", "Doe", "jane.doe@gmail.com");
       const { status, body } = await request(app)
-        .delete(`/invite/${invite.inviteId}/class/${classroom.id}`)
+        .delete(`/api/invite/${invite.inviteId}/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser3.token}`);
 
       expect(status).toBe(403);
@@ -533,7 +533,7 @@ describe("invite tests", async (): Promise<void> => {
         await createTeacher("Jane", "Doe", "jane.doe@gmail.com");
       await addTeacherToClass(teacherUser3.id, classroom.id);
       const { status } = await request(app)
-        .delete(`/invite/${invite.inviteId}/class/${classroom.id}`)
+        .delete(`/api/invite/${invite.inviteId}/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser3.token}`); // teacher3 didn't create the invite, but is part of the class
 
       expect(status).toBe(204);
@@ -549,7 +549,7 @@ describe("invite tests", async (): Promise<void> => {
       });
       // now let's try to delete the non-existent invite using the route
       const { status, body } = await request(app)
-        .delete(`/invite/${invite.inviteId}/class/${classroom.id}`)
+        .delete(`/api/invite/${invite.inviteId}/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(404);
@@ -559,7 +559,7 @@ describe("invite tests", async (): Promise<void> => {
 
     it("should respond with a `400` status code when the params are not correct", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .delete(`/invite/invalid_invite_id/class/invalid_class_id`)
+        .delete(`/api/invite/invalid_invite_id/class/invalid_class_id`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(400);
@@ -583,7 +583,7 @@ describe("invite tests", async (): Promise<void> => {
       const teacherUser3: User & { teacher: Teacher; token: string } =
         await createTeacher("Jane", "Doe", "jane.doe@gmail.com");
       const { status, body } = await request(app)
-        .delete(`/invite/${invite.inviteId}/class/${classroom.id}`)
+        .delete(`/api/invite/${invite.inviteId}/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser3.token}`); // not part of the class
 
       expect(status).toBe(403);
@@ -623,7 +623,7 @@ describe("invite tests", async (): Promise<void> => {
 
       // test getting the invites
       const { status, body } = await request(app)
-        .get(`/invite/class/${classroom.id}`)
+        .get(`/api/invite/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);
@@ -633,7 +633,7 @@ describe("invite tests", async (): Promise<void> => {
     it("should respond with a `403` status code when the teacher is not part of the class", async (): Promise<void> => {
       // try to get invites for a class where the teacher is part of the class
       const { status, body } = await request(app)
-        .get(`/invite/class/${classroom.id}`)
+        .get(`/api/invite/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(403);
@@ -644,7 +644,7 @@ describe("invite tests", async (): Promise<void> => {
 
     it("should respond with a `400` status code when the params are not correct", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/invite/class/invalid_class_id`)
+        .get(`/api/invite/class/invalid_class_id`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(400);

--- a/dwengo_backend/tests/integratie/joinRequest.test.ts
+++ b/dwengo_backend/tests/integratie/joinRequest.test.ts
@@ -73,7 +73,7 @@ describe("join request tests", async (): Promise<void> => {
     it("should respond with a `404` status code when the class does not exist", async (): Promise<void> => {
       // try to send a join request for a class with a non-existent class code
       const { status, body } = await request(app)
-        .post("/join-request/student")
+        .post("/api/join-request/student")
         .set("Authorization", `Bearer ${studentUser1.token}`)
         .send({
           joinCode: "BLABLA", // non-existent class code
@@ -95,7 +95,7 @@ describe("join request tests", async (): Promise<void> => {
     it("should respond with a `409` status code when student is already a member of the class", async (): Promise<void> => {
       await addStudentToClass(studentUser1.id, classroom.id);
       const { status, body } = await request(app)
-        .post("/join-request/student")
+        .post("/api/join-request/student")
         .set("Authorization", `Bearer ${studentUser1.token}`)
         .send({
           joinCode: classroom.code,
@@ -108,7 +108,7 @@ describe("join request tests", async (): Promise<void> => {
     it("should respond with a `409` status code when there is already a pending join request for the student and class", async (): Promise<void> => {
       // send a first join request
       await request(app)
-        .post("/join-request/student")
+        .post("/api/join-request/student")
         .set("Authorization", `Bearer ${studentUser1.token}`)
         .send({
           joinCode: classroom.code,
@@ -121,7 +121,7 @@ describe("join request tests", async (): Promise<void> => {
         });
       // send a second join request
       const { status, body } = await request(app)
-        .post("/join-request/student")
+        .post("/api/join-request/student")
         .set("Authorization", `Bearer ${studentUser1.token}`)
         .send({
           joinCode: classroom.code,
@@ -150,7 +150,7 @@ describe("join request tests", async (): Promise<void> => {
       // test approving the join request
       const { status, body } = await request(app)
         .patch(
-          `/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
+          `/api/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
         )
         .set("Authorization", `Bearer ${teacherUser1.token}`) // teacherUser1 is a teacher of the class
         .send({
@@ -174,7 +174,7 @@ describe("join request tests", async (): Promise<void> => {
       // test denying the join request
       const { status, body } = await request(app)
         .patch(
-          `/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
+          `/api/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
         )
         .set("Authorization", `Bearer ${teacherUser1.token}`) // teacherUser1 is a teacher of the class
         .send({
@@ -200,7 +200,7 @@ describe("join request tests", async (): Promise<void> => {
       // test sending an invalid action
       const { status, body } = await request(app)
         .patch(
-          `/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
+          `/api/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
         )
         .set("Authorization", `Bearer ${teacherUser1.token}`) // teacherUser1 is a teacher of the class
         .send({
@@ -244,7 +244,7 @@ describe("join request tests", async (): Promise<void> => {
     async function approveAndVerifyJoinRequest(): Promise<void> {
       const { status, body } = await request(app)
         .patch(
-          `/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
+          `/api/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
         )
         .set("Authorization", `Bearer ${teacherUser1.token}`) // teacherUser1 is a teacher of the class
         .send({
@@ -265,7 +265,7 @@ describe("join request tests", async (): Promise<void> => {
       // try having teacherUser2 approve the join request
       const { status, body } = await request(app)
         .patch(
-          `/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
+          `/api/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
         )
         .set("Authorization", `Bearer ${teacherUser2.token}`) // teacherUser2 is not a teacher of the class
         .send({
@@ -310,7 +310,7 @@ describe("join request tests", async (): Promise<void> => {
     async function denyAndVerifyJoinRequest(): Promise<void> {
       const { status, body } = await request(app)
         .patch(
-          `/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
+          `/api/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
         )
         .set("Authorization", `Bearer ${teacherUser1.token}`) // teacherUser1 is a teacher of the class
         .send({
@@ -331,7 +331,7 @@ describe("join request tests", async (): Promise<void> => {
       // try having teacherUser2 approve the join request
       const { status, body } = await request(app)
         .patch(
-          `/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
+          `/api/join-request/teacher/${joinRequest.requestId}/class/${classroom.id}`,
         )
         .set("Authorization", `Bearer ${teacherUser2.token}`) // teacherUser2 is not a teacher of the class
         .send({
@@ -361,7 +361,7 @@ describe("join request tests", async (): Promise<void> => {
     it("should respond with a `200` status code and a list of join requests", async (): Promise<void> => {
       // test getting the join requests
       const { status, body } = await request(app)
-        .get(`/join-request/teacher/class/${classroom.id}`)
+        .get(`/api/join-request/teacher/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`); // teacherUser1 is a teacher of the class
 
       expect(status).toBe(200);
@@ -374,7 +374,7 @@ describe("join request tests", async (): Promise<void> => {
         await createTeacher("Hi", "Ho", "hiho@gmail.com");
       // try having teacherUser2 view the join requests
       const { status, body } = await request(app)
-        .get(`/join-request/teacher/class/${classroom.id}`)
+        .get(`/api/join-request/teacher/class/${classroom.id}`)
         .set("Authorization", `Bearer ${teacherUser2.token}`); // teacherUser2 is not a teacher of the class
 
       expect(status).toBe(403);
@@ -390,7 +390,7 @@ async function createJoinCodeAndCheckExistence(
   classroom: Class,
 ): Promise<JoinRequest | null> {
   const { status, body } = await request(app)
-    .post("/join-request/student")
+    .post("/api/join-request/student")
     .set("Authorization", `Bearer ${user.token}`)
     .send({
       joinCode: classroom.code,

--- a/dwengo_backend/tests/integratie/learningObject.test.ts
+++ b/dwengo_backend/tests/integratie/learningObject.test.ts
@@ -36,7 +36,7 @@ describe("learning object tests", { timeout: 15000 }, async () => {
   describe("[GET] learningObject/teacher", async () => {
     it("should return all learning objects", async () => {
       const { status, body } = await request(app)
-        .get("/learningObject/teacher")
+        .get("/api/learningObject/teacher")
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);
@@ -55,7 +55,7 @@ describe("learning object tests", { timeout: 15000 }, async () => {
 
     it("shouldn't let a student access this route", async () => {
       const { status, body } = await request(app)
-        .get("/learningObject/teacher")
+        .get("/api/learningObject/teacher")
         .set("Authorization", `Bearer ${studentUser1.token}`);
 
       expect(status).toBe(401);
@@ -67,7 +67,7 @@ describe("learning object tests", { timeout: 15000 }, async () => {
     it("should return all learning objects that match the search term", async () => {
       const searchTerm: string = "voorbeeld";
       const { status, body } = await request(app)
-        .get(`/learningObject/teacher/search?q=${searchTerm}`)
+        .get(`/api/learningObject/teacher/search?q=${searchTerm}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);
@@ -98,12 +98,12 @@ describe("learning object tests", { timeout: 15000 }, async () => {
 
       // search for the term in lowercase
       const res1 = await request(app)
-        .get("/learningObject/teacher/search?q=voorbeeld")
+        .get("/api/learningObject/teacher/search?q=voorbeeld")
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       // search for the term in uppercase
       const res2 = await request(app)
-        .get("/learningObject/teacher/search?q=VOORBEELD")
+        .get("/api/learningObject/teacher/search?q=VOORBEELD")
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       // results should be the same
@@ -124,7 +124,7 @@ describe("learning object tests", { timeout: 15000 }, async () => {
 
     it("shouldn't let a student access this route", async () => {
       const { status, body } = await request(app)
-        .get("/learningObject/teacher/search?q=voorbeeld")
+        .get("/api/learningObject/teacher/search?q=voorbeeld")
         .set("Authorization", `Bearer ${studentUser1.token}`);
 
       expect(status).toBe(401);
@@ -136,7 +136,7 @@ describe("learning object tests", { timeout: 15000 }, async () => {
     it("should return the local learning object with the given hruid, language and version", async () => {
       const { status, body } = await request(app)
         .get(
-          `/learningObject/teacher/lookup/${lo.hruid}/${lo.language}/${lo.version}`,
+          `/api/learningObject/teacher/lookup/${lo.hruid}/${lo.language}/${lo.version}`,
         )
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
@@ -149,13 +149,13 @@ describe("learning object tests", { timeout: 15000 }, async () => {
     it("should return the dwengo learning object with the given hruid, language and version", async () => {
       // get an existing dwengo learning object
       const res1 = await request(app)
-        .get("/learningObject/teacher")
+        .get("/api/learningObject/teacher")
         .set("Authorization", `Bearer ${teacherUser1.token}`);
       const dwengo_lo: LearningObject = res1.body[0]; // get first dwengo learning object
 
       const { status, body } = await request(app)
         .get(
-          `/learningObject/teacher/lookup/${dwengo_lo.hruid}/${dwengo_lo.language}/${dwengo_lo.version}`,
+          `/api/learningObject/teacher/lookup/${dwengo_lo.hruid}/${dwengo_lo.language}/${dwengo_lo.version}`,
         )
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
@@ -168,7 +168,7 @@ describe("learning object tests", { timeout: 15000 }, async () => {
     it("should return 404 if the learning object doesn't exist", async () => {
       const { status, body } = await request(app)
         .get(
-          `/learningObject/teacher/lookup/invalidhruid/invalidlang/112423904`, // non-existing hruid, language and version
+          `/api/learningObject/teacher/lookup/invalidhruid/invalidlang/112423904`, // non-existing hruid, language and version
         )
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
@@ -179,7 +179,7 @@ describe("learning object tests", { timeout: 15000 }, async () => {
     it("shouldn't let a student access this route", async () => {
       const { status, body } = await request(app)
         .get(
-          `/learningObject/teacher/lookup/${lo.hruid}/${lo.language}/${lo.version}`,
+          `/api/learningObject/teacher/lookup/${lo.hruid}/${lo.language}/${lo.version}`,
         )
         .set("Authorization", `Bearer ${studentUser1.token}`);
 
@@ -194,7 +194,7 @@ describe("learning object tests", { timeout: 15000 }, async () => {
     // if this is fixed in the future, this test case should be added
     it("should return the local learning object with the given id", async () => {
       const { status, body } = await request(app)
-        .get(`/learningObject/${lo.id}`)
+        .get(`/api/learningObject/${lo.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);
@@ -203,7 +203,7 @@ describe("learning object tests", { timeout: 15000 }, async () => {
 
     it("shouldn't let an unauthorized user use this route", async () => {
       const { status, body } = await request(app).get(
-        `/learningObject/${lo.id}`,
+        `/api/learningObject/${lo.id}`,
       ); // don't add auth header
 
       expect(status).toBe(401);
@@ -216,13 +216,13 @@ describe("learning object tests", { timeout: 15000 }, async () => {
     beforeEach(async () => {
       // get a dwengo learning path
       const res = await request(app)
-        .get("/learningPath?all=")
+        .get("/api/learningPath?all=")
         .set("Authorization", `Bearer ${teacherUser1.token}`);
       lp = res.body[0]; // get first dwengo learning path
     }, 20_000);
     it("should return all learning objects that belong to the given learning path", async () => {
       const { status, body } = await request(app)
-        .get(`/learningObject/learningPath/${lp._id}`)
+        .get(`/api/learningObject/learningPath/${lp._id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);

--- a/dwengo_backend/tests/integratie/localLearningObject.test.ts
+++ b/dwengo_backend/tests/integratie/localLearningObject.test.ts
@@ -41,7 +41,7 @@ describe("local learning object tests", async () => {
     });
     it("should return all learning objects of the teacher", async () => {
       const { status, body } = await request(app)
-        .get("/learningObjectByTeacher")
+        .get("/api/learningObjectByTeacher")
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);
@@ -59,7 +59,7 @@ describe("local learning object tests", async () => {
     });
     it("shouldn't let a student access this route", async () => {
       const { status, body } = await request(app)
-        .get("/learningObjectByTeacher")
+        .get("/api/learningObjectByTeacher")
         .set("Authorization", `Bearer ${studentUser1.token}`);
 
       expect(status).toBe(401);
@@ -69,7 +69,7 @@ describe("local learning object tests", async () => {
       // there are some local learning objects created by another teacher
       // test that another teacher can't see them
       const { status, body } = await request(app)
-        .get("/learningObjectByTeacher")
+        .get("/api/learningObjectByTeacher")
         .set("Authorization", `Bearer ${teacherUser2.token}`);
 
       expect(status).toBe(200);
@@ -80,7 +80,7 @@ describe("local learning object tests", async () => {
   describe("[POST] /learningObjectByTeacher", async () => {
     it("should create a new learning object", async () => {
       const { status, body } = await request(app)
-        .post("/learningObjectByTeacher")
+        .post("/api/learningObjectByTeacher")
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send(data);
 
@@ -102,7 +102,7 @@ describe("local learning object tests", async () => {
     });
     it("shouldn't let a student create a learning object", async () => {
       const { status, body } = await request(app)
-        .post("/learningObjectByTeacher")
+        .post("/api/learningObjectByTeacher")
         .set("Authorization", `Bearer ${studentUser1.token}`)
         .send(data);
 
@@ -129,7 +129,7 @@ describe("local learning object tests", async () => {
     });
     it("should return the learning object with the given id", async () => {
       const { status, body } = await request(app)
-        .get(`/learningObjectByTeacher/${lo.id}`)
+        .get(`/api/learningObjectByTeacher/${lo.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(200);
@@ -137,7 +137,7 @@ describe("local learning object tests", async () => {
     });
     it("should return an error if the learning object doesn't exist", async () => {
       const { status, body } = await request(app)
-        .get("/learningObjectByTeacher/123456789") // non-existing learning object id
+        .get("/api/learningObjectByTeacher/123456789") // non-existing learning object id
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(404);
@@ -145,7 +145,7 @@ describe("local learning object tests", async () => {
     });
     it("shouldn't let a student access this route", async () => {
       const { status, body } = await request(app)
-        .get(`/learningObjectByTeacher/${lo.id}`)
+        .get(`/api/learningObjectByTeacher/${lo.id}`)
         .set("Authorization", `Bearer ${studentUser1.token}`);
 
       expect(status).toBe(401);
@@ -153,7 +153,7 @@ describe("local learning object tests", async () => {
     });
     it("shouldn't let another teacher get the learning object", async () => {
       const { status, body } = await request(app)
-        .get(`/learningObjectByTeacher/${lo.id}`)
+        .get(`/api/learningObjectByTeacher/${lo.id}`)
         .set("Authorization", `Bearer ${teacherUser2.token}`);
 
       expect(status).toBe(403);
@@ -172,7 +172,7 @@ describe("local learning object tests", async () => {
       const lo = await createLearningObject(teacherUser1.id, data);
 
       const { status, body } = await request(app)
-        .patch(`/learningObjectByTeacher/${lo.id}`)
+        .patch(`/api/learningObjectByTeacher/${lo.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send(updatedData);
 
@@ -194,7 +194,7 @@ describe("local learning object tests", async () => {
     });
     it("should return an error if the learning object doesn't exist", async () => {
       const { status, body } = await request(app)
-        .patch("/learningObjectByTeacher/123456789") // non-existing learning object id
+        .patch("/api/learningObjectByTeacher/123456789") // non-existing learning object id
         .set("Authorization", `Bearer ${teacherUser1.token}`)
         .send(updatedData);
 
@@ -205,7 +205,7 @@ describe("local learning object tests", async () => {
     it("shouldn't let a student update a learning object", async () => {
       const lo = await createLearningObject(teacherUser1.id, data);
       const { status, body } = await request(app)
-        .patch(`/learningObjectByTeacher/${lo.id}`)
+        .patch(`/api/learningObjectByTeacher/${lo.id}`)
         .set("Authorization", `Bearer ${studentUser1.token}`)
         .send(updatedData);
 
@@ -227,7 +227,7 @@ describe("local learning object tests", async () => {
     it("shouldn't let another teacher update the learning object", async () => {
       const lo = await createLearningObject(teacherUser1.id, data);
       const { status, body } = await request(app)
-        .patch(`/learningObjectByTeacher/${lo.id}`)
+        .patch(`/api/learningObjectByTeacher/${lo.id}`)
         .set("Authorization", `Bearer ${teacherUser2.token}`) // another teacher tries to update the learning object
         .send(updatedData);
 
@@ -253,7 +253,7 @@ describe("local learning object tests", async () => {
       const lo = await createLearningObject(teacherUser1.id, data);
 
       const { status } = await request(app)
-        .delete(`/learningObjectByTeacher/${lo.id}`)
+        .delete(`/api/learningObjectByTeacher/${lo.id}`)
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(204);
@@ -271,7 +271,7 @@ describe("local learning object tests", async () => {
     });
     it("should return an error if the learning object doesn't exist", async () => {
       const { status, body } = await request(app)
-        .delete("/learningObjectByTeacher/123456789") // non-existing learning object id
+        .delete("/api/learningObjectByTeacher/123456789") // non-existing learning object id
         .set("Authorization", `Bearer ${teacherUser1.token}`);
 
       expect(status).toBe(404);
@@ -281,7 +281,7 @@ describe("local learning object tests", async () => {
     it("shouldn't let a student delete a learning object", async () => {
       const lo = await createLearningObject(teacherUser1.id, data);
       const response = await request(app)
-        .delete(`/learningObjectByTeacher/${lo.id}`)
+        .delete(`/api/learningObjectByTeacher/${lo.id}`)
         .set("Authorization", `Bearer ${studentUser1.token}`);
 
       expect(response.status).toBe(401);
@@ -301,7 +301,7 @@ describe("local learning object tests", async () => {
     it("shouldn't let another teacher delete the learning object", async () => {
       const lo = await createLearningObject(teacherUser1.id, data);
       const response = await request(app)
-        .delete(`/learningObjectByTeacher/${lo.id}`)
+        .delete(`/api/learningObjectByTeacher/${lo.id}`)
         .set("Authorization", `Bearer ${teacherUser2.token}`); // another teacher tries to delete the learning object
 
       expect(response.status).toBe(403);

--- a/dwengo_backend/tests/integratie/studentAssignment.test.ts
+++ b/dwengo_backend/tests/integratie/studentAssignment.test.ts
@@ -125,7 +125,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
         this list will be empty because student doesn't have any assignments", async (): Promise<void> => {
       // set up scenario where student has no assignments
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .set("Authorization", `Bearer ${student1.token}`);
 
       expect(status).toBe(200);
@@ -134,7 +134,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should respond with a `200` status code and a list of 2 assignments", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .set("Authorization", `Bearer ${student2.token}`);
 
       expect(status).toBe(200);
@@ -150,7 +150,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should return the same array of assignments for all students in the same class", async (): Promise<void> => {
       let req = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .set("Authorization", `Bearer ${student2.token}`);
 
       const s: number = req.status;
@@ -160,7 +160,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
       expect(b).toHaveLength(2);
 
       req = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .set("Authorization", `Bearer ${student3.token}`);
 
       const s1: number = req.status;
@@ -175,7 +175,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should not return the same array of assignments for students in other classes", async (): Promise<void> => {
       let req = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .set("Authorization", `Bearer ${student2.token}`);
 
       const s: number = req.status;
@@ -185,7 +185,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
       expect(b).toHaveLength(2);
 
       req = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .set("Authorization", `Bearer ${student4.token}`);
 
       const s1: number = req.status;
@@ -201,7 +201,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should return a sorted list of assignments in descending order based on the deadline", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .query({ sort: "deadline", order: "desc" })
         .set("Authorization", `Bearer ${student5.token}`);
 
@@ -214,7 +214,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should return a sorted list of assignments in ascending order based on the deadline", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .query({ sort: "deadline", order: "asc" })
         .set("Authorization", `Bearer ${student5.token}`);
 
@@ -227,7 +227,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should return a sorted list of assignments in descending order based on createdAt", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .query({ sort: "createdAt", order: "desc" })
         .set("Authorization", `Bearer ${student5.token}`);
 
@@ -240,7 +240,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should return a sorted list of assignments in ascending order based on createdAt", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .query({ sort: "createdAt", order: "asc" })
         .set("Authorization", `Bearer ${student5.token}`);
 
@@ -253,7 +253,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should return a sorted list of assignments in descending order based on updatedAt", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .query({ sort: "updatedAt", order: "desc" })
         .set("Authorization", `Bearer ${student5.token}`);
 
@@ -266,7 +266,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should return a sorted list of assignments in ascending order based on updatedAt", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .query({ sort: "updatedAt", order: "asc" })
         .set("Authorization", `Bearer ${student5.token}`);
 
@@ -279,7 +279,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should return a sorted list of 1 assignment due to limit", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .query({ limit: 1 })
         .set("Authorization", `Bearer ${student5.token}`);
 
@@ -291,7 +291,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should only return 2 assignments even though limit is higher", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get("/assignment/student")
+        .get("/api/assignment/student")
         .query({ limit: 10 })
         .set("Authorization", `Bearer ${student5.token}`);
 
@@ -307,7 +307,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
         this list will be empty because student doesn't have any assignments", async (): Promise<void> => {
       // set up scenario where student has no assignments
       const { status, body } = await request(app)
-        .get(`/assignment/student/class/${class4.id}`)
+        .get(`/api/assignment/student/class/${class4.id}`)
         .set("Authorization", `Bearer ${student2.token}`);
 
       expect(status).toBe(200);
@@ -316,7 +316,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should respond with a `200` status code and a list of 2 assignments", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/assignment/student/class/${class1.id}`)
+        .get(`/api/assignment/student/class/${class1.id}`)
         .set("Authorization", `Bearer ${student2.token}`);
 
       expect(status).toBe(200);
@@ -332,7 +332,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
     it("should return the same array of assignments for all students in the same class", async (): Promise<void> => {
       let req = await request(app)
-        .get(`/assignment/student/class/${class1.id}`)
+        .get(`/api/assignment/student/class/${class1.id}`)
         .set("Authorization", `Bearer ${student2.token}`);
 
       const s: number = req.status;
@@ -342,7 +342,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
       expect(b).toHaveLength(2);
 
       req = await request(app)
-        .get(`/assignment/student/class/${class1.id}`)
+        .get(`/api/assignment/student/class/${class1.id}`)
         .set("Authorization", `Bearer ${student3.token}`);
 
       const s1: number = req.status;
@@ -358,7 +358,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
   it("should respond with a `403` status code when student is not in class", async (): Promise<void> => {
     const { status, body } = await request(app)
-      .get(`/assignment/student/class/${class4.id}`)
+      .get(`/api/assignment/student/class/${class4.id}`)
       .set("Authorization", `Bearer ${student1.token}`);
 
     expect(status).toBe(403);
@@ -367,7 +367,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
   it("should return a sorted list of assignments in descending order based on the deadline", async (): Promise<void> => {
     const { status, body } = await request(app)
-      .get(`/assignment/student/class/${class3.id}`)
+      .get(`/api/assignment/student/class/${class3.id}`)
       .query({ sort: "deadline", order: "desc" })
       .set("Authorization", `Bearer ${student5.token}`);
 
@@ -380,7 +380,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
   it("should return a sorted list of assignments in ascending order based on the deadline", async (): Promise<void> => {
     const { status, body } = await request(app)
-      .get(`/assignment/student/class/${class3.id}`)
+      .get(`/api/assignment/student/class/${class3.id}`)
       .query({ sort: "deadline", order: "asc" })
       .set("Authorization", `Bearer ${student5.token}`);
 
@@ -393,7 +393,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
   it("should return a sorted list of assignments in descending order based on createdAt", async (): Promise<void> => {
     const { status, body } = await request(app)
-      .get(`/assignment/student/class/${class3.id}`)
+      .get(`/api/assignment/student/class/${class3.id}`)
       .query({ sort: "createdAt", order: "desc" })
       .set("Authorization", `Bearer ${student5.token}`);
 
@@ -406,7 +406,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
   it("should return a sorted list of assignments in ascending order based on createdAt", async (): Promise<void> => {
     const { status, body } = await request(app)
-      .get(`/assignment/student/class/${class3.id}`)
+      .get(`/api/assignment/student/class/${class3.id}`)
       .query({ sort: "createdAt", order: "asc" })
       .set("Authorization", `Bearer ${student5.token}`);
 
@@ -419,7 +419,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
   it("should return a sorted list of assignments in descending order based on updatedAt", async (): Promise<void> => {
     const { status, body } = await request(app)
-      .get(`/assignment/student/class/${class3.id}`)
+      .get(`/api/assignment/student/class/${class3.id}`)
       .query({ sort: "updatedAt", order: "desc" })
       .set("Authorization", `Bearer ${student5.token}`);
 
@@ -432,7 +432,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
   it("should return a sorted list of assignments in ascending order based on updatedAt", async (): Promise<void> => {
     const { status, body } = await request(app)
-      .get(`/assignment/student/class/${class3.id}`)
+      .get(`/api/assignment/student/class/${class3.id}`)
       .query({ sort: "updatedAt", order: "asc" })
       .set("Authorization", `Bearer ${student5.token}`);
 
@@ -445,7 +445,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
   it("should return a sorted list of 1 assignment due to limit", async (): Promise<void> => {
     const { status, body } = await request(app)
-      .get(`/assignment/student/class/${class3.id}`)
+      .get(`/api/assignment/student/class/${class3.id}`)
       .query({ limit: 1 })
       .set("Authorization", `Bearer ${student5.token}`);
 
@@ -457,7 +457,7 @@ describe("[GET] /assignment/student", async (): Promise<void> => {
 
   it("should only return 2 assignments even though limit is higher", async (): Promise<void> => {
     const { status, body } = await request(app)
-      .get(`/assignment/student/class/${class3.id}`)
+      .get(`/api/assignment/student/class/${class3.id}`)
       .query({ limit: 10 })
       .set("Authorization", `Bearer ${student5.token}`);
 

--- a/dwengo_backend/tests/integratie/submissions.test.ts
+++ b/dwengo_backend/tests/integratie/submissions.test.ts
@@ -74,7 +74,7 @@ describe("Submission tests", (): void => {
 
       const { status, body } = await request(app)
         .post(
-          `/submission/student/assignment/${assignmentId}/evaluation/${evalId}`,
+          `/api/submission/student/assignment/${assignmentId}/evaluation/${evalId}`,
         )
         .set("Authorization", `Bearer ${student.token}`);
 
@@ -88,7 +88,7 @@ describe("Submission tests", (): void => {
     it("Should respond with a `201` status code and the created submission", async (): Promise<void> => {
       const { status, body } = await request(app)
         .post(
-          `/submission/student/assignment/${assignmentId}/evaluation/${evalId}`,
+          `/api/submission/student/assignment/${assignmentId}/evaluation/${evalId}`,
         )
         .set("Authorization", `Bearer ${student.token}`);
 
@@ -108,7 +108,7 @@ describe("Submission tests", (): void => {
   describe("[GET] /submission/student/assignment/:assignmentId", (): void => {
     it("Should respond with a `200` status code and return the submission for an assignment", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/submission/student/assignment/${assignmentId}`)
+        .get(`/api/submission/student/assignment/${assignmentId}`)
         .set("Authorization", `Bearer ${student.token}`);
 
       expectSuccessfulSubmissionRetrieval(status, body);
@@ -118,7 +118,7 @@ describe("Submission tests", (): void => {
   describe("[GET] /submission/student/:studentId", (): void => {
     it("Should respond with a `401` status code because a teacher is unauthorized", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/submission/student/${studentId}`)
+        .get(`/api/submission/student/${studentId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expect(status).toBe(401);
@@ -131,7 +131,7 @@ describe("Submission tests", (): void => {
     it("Should respond with a `200` status code and return the submission for an evaluation", async (): Promise<void> => {
       const { status, body } = await request(app)
         .get(
-          `/submission/student/assignment/${assignmentId}/evaluation/${evalId}`,
+          `/api/submission/student/assignment/${assignmentId}/evaluation/${evalId}`,
         )
         .set("Authorization", `Bearer ${student.token}`);
 
@@ -142,7 +142,7 @@ describe("Submission tests", (): void => {
   describe("[GET] /submissions/teacher/student/:studentId", (): void => {
     it("Should respond with a `401` status code because a student is unauthorized", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/submission/teacher/student/${studentId}`)
+        .get(`/api/submission/teacher/student/${studentId}`)
         .set("Authorization", `Bearer ${student.token}`);
 
       expect(status).toBe(401);
@@ -154,7 +154,7 @@ describe("Submission tests", (): void => {
   describe("[GET] /submission/teacher/student/:studentId", (): void => {
     it("Should respond with a `200` status code and return the submissions for a student", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/submission/teacher/student/${studentId}`)
+        .get(`/api/submission/teacher/student/${studentId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expectSuccessfulSubmissionRetrieval(status, body);
@@ -164,7 +164,7 @@ describe("Submission tests", (): void => {
   describe("[GET] /submission/teacher/team/:teamId", (): void => {
     it("Should respond with a `200` status code and return the submissions for a team", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/submission/teacher/team/${teamId}`)
+        .get(`/api/submission/teacher/team/${teamId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expectSuccessfulSubmissionRetrieval(status, body);
@@ -174,7 +174,7 @@ describe("Submission tests", (): void => {
   describe("[GET] /submission/teacher/student/:studentId", (): void => {
     it("Should respond with a `200` status code and return the submissions for a specific assignment and student", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/submission/teacher/student/${studentId}`)
+        .get(`/api/submission/teacher/student/${studentId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expectSuccessfulSubmissionRetrieval(status, body);
@@ -184,7 +184,7 @@ describe("Submission tests", (): void => {
   describe("[GET] /submission/teacher/team/:teamId", (): void => {
     it("Should respond with a `200` status code and return the submissions for a specific assignment and team", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/submission/teacher/team/${teamId}`)
+        .get(`/api/submission/teacher/team/${teamId}`)
         .set("Authorization", `Bearer ${teacher.token}`);
 
       expectSuccessfulSubmissionRetrieval(status, body);

--- a/dwengo_backend/tests/integratie/teacherAssignment.test.ts
+++ b/dwengo_backend/tests/integratie/teacherAssignment.test.ts
@@ -108,7 +108,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `201` status code and the newly created assignment", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .post("/assignment/teacher")
+        .post("/api/assignment/teacher")
         .set("Authorization", `Bearer ${teacher1.token}`)
         .send({
           classId: class3.id,
@@ -129,7 +129,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `401` status code because a student is not allowed to perform this action", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .post("/assignment/teacher")
+        .post("/api/assignment/teacher")
         .set("Authorization", `Bearer ${student.token}`)
         .send({
           classId: class3.id,
@@ -147,7 +147,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `403` status code because the teacher is not a member of the class", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .post("/assignment/teacher")
+        .post("/api/assignment/teacher")
         .set("Authorization", `Bearer ${teacher2.token}`)
         .send({
           classId: class3.id,
@@ -165,7 +165,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `400` status code because there is no language given", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .post("/assignment/teacher")
+        .post("/api/assignment/teacher")
         .set("Authorization", `Bearer ${teacher1.token}`)
         .send({
           classId: class3.id,
@@ -186,7 +186,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `400` status code because there is no pathRef given", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .post("/assignment/teacher")
+        .post("/api/assignment/teacher")
         .set("Authorization", `Bearer ${teacher1.token}`)
         .send({
           classId: class3.id,
@@ -207,7 +207,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `400` status code because there is no localId given", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .post("/assignment/teacher")
+        .post("/api/assignment/teacher")
         .set("Authorization", `Bearer ${teacher1.token}`)
         .send({
           classId: class3.id,
@@ -227,7 +227,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `404` status code because there is no existing localId given", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .post("/assignment/teacher")
+        .post("/api/assignment/teacher")
         .set("Authorization", `Bearer ${teacher1.token}`)
         .send({
           classId: class3.id,
@@ -247,7 +247,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
   describe("[GET] /assignment/teacher/class/:classId", async (): Promise<void> => {
     it("should respond with a `200` status code and a list of assignments for that class", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/assignment/teacher/class/${class1.id}`)
+        .get(`/api/assignment/teacher/class/${class1.id}`)
         .set("Authorization", `Bearer ${teacher1.token}`);
 
       expect(status).toBe(200);
@@ -262,11 +262,11 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
 
     it("should respond with the same assignments for teachers that are members of the same class", async (): Promise<void> => {
       const req = await request(app)
-        .get(`/assignment/teacher/class/${class1.id}`)
+        .get(`/api/assignment/teacher/class/${class1.id}`)
         .set("Authorization", `Bearer ${teacher1.token}`);
 
       const req2 = await request(app)
-        .get(`/assignment/teacher/class/${class1.id}`)
+        .get(`/api/assignment/teacher/class/${class1.id}`)
         .set("Authorization", `Bearer ${teacher2.token}`);
 
       expect(req.status).toBe(200);
@@ -280,7 +280,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
 
     it("should respond with an error because the teacher is not part of the class", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/assignment/teacher/class/${class1.id}`)
+        .get(`/api/assignment/teacher/class/${class1.id}`)
         .set("Authorization", `Bearer ${teacher3.token}`);
       expect(status).toBe(403);
       expect(body.error).toBe("AccessDeniedError");
@@ -292,7 +292,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `201` status code and the updated assignment", async (): Promise<void> => {
       // First create assignment for class3
       const { status, body } = await request(app)
-        .post(`/assignment/teacher`)
+        .post(`/api/assignment/teacher`)
         .set("Authorization", `Bearer ${teacher1.token}`)
         .send({
           classId: class3.id,
@@ -308,7 +308,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
       const assignmentId: number = body.assignment.id;
 
       const req = await request(app)
-        .patch(`/assignment/teacher/${assignmentId}`)
+        .patch(`/api/assignment/teacher/${assignmentId}`)
         .set("Authorization", `Bearer ${teacher1.token}`)
         .send({
           pathRef: lp2.id,
@@ -331,7 +331,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
         "david@gmail.com",
       );
       const { status, body } = await request(app)
-        .patch(`/assignment/teacher/${assignment1.id}`)
+        .patch(`/api/assignment/teacher/${assignment1.id}`)
         .set("Authorization", `Bearer ${newTeacher.token}`)
         .send({
           learningPathId: lp2.id,
@@ -345,7 +345,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `404` status code because the teacher is not a member of the class", async (): Promise<void> => {
       // First create assignment for class3
       await request(app)
-        .post("/assignment/teacher")
+        .post("/api/assignment/teacher")
         .set("Authorization", `Bearer ${teacher1.token}`)
         .send({
           classId: class3.id,
@@ -354,7 +354,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
         });
 
       const { status, body } = await request(app)
-        .patch(`/assignment/teacher/${assignment1.id}`)
+        .patch(`/api/assignment/teacher/${assignment1.id}`)
         .set("Authorization", `Bearer ${teacher3.token}`)
         .send({
           learningPathId: lp2.id,
@@ -370,7 +370,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `400` status code because there is no language given", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .patch(`/assignment/teacher/${assignment1.id}`)
+        .patch(`/api/assignment/teacher/${assignment1.id}`)
         .set("Authorization", `Bearer ${teacher2.token}`)
         .send({
           classId: class3.id,
@@ -391,7 +391,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `400` status code because there is no pathRef given", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .patch(`/assignment/teacher/${assignment1.id}`)
+        .patch(`/api/assignment/teacher/${assignment1.id}`)
         .set("Authorization", `Bearer ${teacher2.token}`)
         .send({
           classId: class3.id,
@@ -413,7 +413,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `400` status code because there is no localId given", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .patch(`/assignment/teacher/${assignment1.id}`)
+        .patch(`/api/assignment/teacher/${assignment1.id}`)
         .set("Authorization", `Bearer ${teacher2.token}`)
         .send({
           classId: class3.id,
@@ -433,7 +433,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `404` status code because there is no existing localId given", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .patch(`/assignment/teacher/${assignment1.id}`)
+        .patch(`/api/assignment/teacher/${assignment1.id}`)
         .set("Authorization", `Bearer ${teacher2.token}`)
         .send({
           classId: class3.id,
@@ -453,7 +453,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
   describe("[DELETE] /assignment/teacher/:assignmentId", async (): Promise<void> => {
     it("should respond with a `204` status code and delete the assignment", async (): Promise<void> => {
       const { status } = await request(app)
-        .delete(`/assignment/teacher/${assignment3.id}`)
+        .delete(`/api/assignment/teacher/${assignment3.id}`)
         .set("Authorization", `Bearer ${teacher2.token}`);
       expect(status).toBe(204);
 
@@ -466,7 +466,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
 
     it("should respond with a `404` status code because the teacher is not a member of the class", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .delete(`/assignment/teacher/${assignment1.id}`)
+        .delete(`/api/assignment/teacher/${assignment1.id}`)
         .set("Authorization", `Bearer ${teacher3.token}`);
 
       expect(status).toBe(404);
@@ -479,7 +479,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
     it("should respond with a `401` status code because a student is not allowed to perform this action", async (): Promise<void> => {
       // class3 has no assignments
       const { status, body } = await request(app)
-        .delete(`/assignment/teacher/${assignment1.id}`)
+        .delete(`/api/assignment/teacher/${assignment1.id}`)
         .set("Authorization", `Bearer ${student.token}`)
         .send({
           classId: class3.id,
@@ -498,7 +498,7 @@ describe("Tests for teacherAssignment", async (): Promise<void> => {
   describe("[GET] /assignment/teacher", async (): Promise<void> => {
     it("should respond with a `200` status code and return all the assignments of the teacher", async (): Promise<void> => {
       const { status, body } = await request(app)
-        .get(`/assignment/teacher`)
+        .get(`/api/assignment/teacher`)
         .set("Authorization", `Bearer ${teacher1.token}`);
 
       expect(status).toBe(200);


### PR DESCRIPTION
Na het toevoegen van de /api prefix in de backend routes, slaagden de testen niet meer. Ik was de routes van de testen vergeten aanpassen. Dit is nu opgelost. Alle backend testen slagen nu opnieuw.